### PR TITLE
Only apply the translation once on childless DisplayObjectContainers

### DIFF
--- a/starling/src/starling/display/DisplayObjectContainer.as
+++ b/starling/src/starling/display/DisplayObjectContainer.as
@@ -228,7 +228,7 @@ package starling.display
             if (numChildren == 0)
             {
                 getTransformationMatrix(targetSpace, sHelperMatrix);
-                var position:Point = sHelperMatrix.transformPoint(new Point(x, y));
+                var position:Point = sHelperMatrix.transformPoint(new Point());
                 return new Rectangle(position.x, position.y);
             }
             else if (numChildren == 1)


### PR DESCRIPTION
When DisplayObjectContainers without children calculate their bounds, they get a Matrix relative to the target space that includes their translation. Then the translation is included again in the calculation of the position by the matrix. This change removes the translation from the call to the matrix.
