### PR TITLE
Fixed bug where buttonMode on flash display objects is broken

### DIFF
--- a/starling/src/starling/display/Button.as
+++ b/starling/src/starling/display/Button.as
@@ -13,7 +13,7 @@ package starling.display
     import flash.geom.Rectangle;
     import flash.ui.Mouse;
     import flash.ui.MouseCursor;
-    
+
     import starling.events.Event;
     import starling.events.Touch;
     import starling.events.TouchEvent;
@@ -25,42 +25,42 @@ package starling.display
 
     /** Dispatched when the user triggers the button. Bubbles. */
     [Event(name="triggered", type="starling.events.Event")]
-    
+
     /** A simple button composed of an image and, optionally, text.
-     *  
-     *  <p>You can pass a texture for up- and downstate of the button. If you do not provide a down 
+     *
+     *  <p>You can pass a texture for up- and downstate of the button. If you do not provide a down
      *  state, the button is simply scaled a little when it is touched.
-     *  In addition, you can overlay a text on the button. To customize the text, almost the 
-     *  same options as those of text fields are provided. In addition, you can move the text to a 
+     *  In addition, you can overlay a text on the button. To customize the text, almost the
+     *  same options as those of text fields are provided. In addition, you can move the text to a
      *  certain position with the help of the <code>textBounds</code> property.</p>
-     *  
+     *
      *  <p>To react on touches on a button, there is special <code>triggered</code>-event type. Use
      *  this event instead of normal touch events - that way, users can cancel button activation
-     *  by moving the mouse/finger away from the button before releasing.</p> 
-     */ 
+     *  by moving the mouse/finger away from the button before releasing.</p>
+     */
     public class Button extends DisplayObjectContainer
     {
         private static const MAX_DRAG_DIST:Number = 50;
-        
+
         private var mUpState:Texture;
         private var mDownState:Texture;
-        
+
         private var mContents:Sprite;
         private var mBackground:Image;
         private var mTextField:TextField;
         private var mTextBounds:Rectangle;
-        
+
         private var mScaleWhenDown:Number;
         private var mAlphaWhenDisabled:Number;
         private var mEnabled:Boolean;
         private var mIsDown:Boolean;
         private var mUseHandCursor:Boolean;
-        
+
         /** Creates a button with textures for up- and down-state or text. */
         public function Button(upState:Texture, text:String="", downState:Texture=null)
         {
             if (upState == null) throw new ArgumentError("Texture cannot be null");
-            
+
             mUpState = upState;
             mDownState = downState ? downState : upState;
             mBackground = new Image(upState);
@@ -69,16 +69,16 @@ package starling.display
             mEnabled = true;
             mIsDown = false;
             mUseHandCursor = true;
-            mTextBounds = new Rectangle(0, 0, upState.width, upState.height);            
-            
+            mTextBounds = new Rectangle(0, 0, upState.width, upState.height);
+
             mContents = new Sprite();
             mContents.addChild(mBackground);
             addChild(mContents);
             addEventListener(TouchEvent.TOUCH, onTouch);
-            
+
             if (text.length != 0) this.text = text;
         }
-        
+
         private function resetContents():void
         {
             mIsDown = false;
@@ -86,7 +86,7 @@ package starling.display
             mContents.x = mContents.y = 0;
             mContents.scaleX = mContents.scaleY = 1.0;
         }
-        
+
         private function createTextField():void
         {
             if (mTextField == null)
@@ -98,21 +98,21 @@ package starling.display
                 mTextField.autoScale = true;
                 mContents.addChild(mTextField);
             }
-            
+
             mTextField.width  = mTextBounds.width;
             mTextField.height = mTextBounds.height;
             mTextField.x = mTextBounds.x;
             mTextField.y = mTextBounds.y;
         }
-        
+
         private function onTouch(event:TouchEvent):void
         {
-            Mouse.cursor = (mUseHandCursor && mEnabled && event.interactsWith(this)) ? 
-                MouseCursor.BUTTON : MouseCursor.ARROW;
-            
+            Mouse.cursor = (mUseHandCursor && mEnabled && event.interactsWith(this)) ?
+                MouseCursor.BUTTON : MouseCursor.AUTO;
+
             var touch:Touch = event.getTouch(this);
             if (!mEnabled || touch == null) return;
-            
+
             if (touch.phase == TouchPhase.BEGAN && !mIsDown)
             {
                 mBackground.texture = mDownState;
@@ -139,16 +139,16 @@ package starling.display
                 dispatchEvent(new Event(Event.TRIGGERED, true));
             }
         }
-        
-        /** The scale factor of the button on touch. Per default, a button with a down state 
+
+        /** The scale factor of the button on touch. Per default, a button with a down state
           * texture won't scale. */
         public function get scaleWhenDown():Number { return mScaleWhenDown; }
         public function set scaleWhenDown(value:Number):void { mScaleWhenDown = value; }
-        
+
         /** The alpha value of the button when it is disabled. @default 0.5 */
         public function get alphaWhenDisabled():Number { return mAlphaWhenDisabled; }
         public function set alphaWhenDisabled(value:Number):void { mAlphaWhenDisabled = value; }
-        
+
         /** Indicates if the button can be triggered. */
         public function get enabled():Boolean { return mEnabled; }
         public function set enabled(value:Boolean):void
@@ -160,7 +160,7 @@ package starling.display
                 resetContents();
             }
         }
-        
+
         /** The text that is displayed on the button. */
         public function get text():String { return mTextField ? mTextField.text : ""; }
         public function set text(value:String):void
@@ -168,8 +168,8 @@ package starling.display
             createTextField();
             mTextField.text = value;
         }
-       
-        /** The name of the font displayed on the button. May be a system font or a registered 
+
+        /** The name of the font displayed on the button. May be a system font or a registered
           * bitmap font. */
         public function get fontName():String { return mTextField ? mTextField.fontName : "Verdana"; }
         public function set fontName(value:String):void
@@ -177,7 +177,7 @@ package starling.display
             createTextField();
             mTextField.fontName = value;
         }
-        
+
         /** The size of the font. */
         public function get fontSize():Number { return mTextField ? mTextField.fontSize : 12; }
         public function set fontSize(value:Number):void
@@ -185,7 +185,7 @@ package starling.display
             createTextField();
             mTextField.fontSize = value;
         }
-        
+
         /** The color of the font. */
         public function get fontColor():uint { return mTextField ? mTextField.color : 0x0; }
         public function set fontColor(value:uint):void
@@ -193,7 +193,7 @@ package starling.display
             createTextField();
             mTextField.color = value;
         }
-        
+
         /** Indicates if the font should be bold. */
         public function get fontBold():Boolean { return mTextField ? mTextField.bold : false; }
         public function set fontBold(value:Boolean):void
@@ -201,7 +201,7 @@ package starling.display
             createTextField();
             mTextField.bold = value;
         }
-        
+
         /** The texture that is displayed when the button is not being touched. */
         public function get upState():Texture { return mUpState; }
         public function set upState(value:Texture):void
@@ -212,7 +212,7 @@ package starling.display
                 if (!mIsDown) mBackground.texture = value;
             }
         }
-        
+
         /** The texture that is displayed while the button is touched. */
         public function get downState():Texture { return mDownState; }
         public function set downState(value:Texture):void
@@ -223,7 +223,7 @@ package starling.display
                 if (mIsDown) mBackground.texture = value;
             }
         }
-        
+
         /** The bounds of the textfield on the button. Allows moving the text to a custom position. */
         public function get textBounds():Rectangle { return mTextBounds.clone(); }
         public function set textBounds(value:Rectangle):void
@@ -231,8 +231,8 @@ package starling.display
             mTextBounds = value.clone();
             createTextField();
         }
-        
-        /** Indicates if the mouse cursor should transform into a hand while it's over the button. 
+
+        /** Indicates if the mouse cursor should transform into a hand while it's over the button.
          *  @default true */
         public function get useHandCursor():Boolean { return mUseHandCursor; }
         public function set useHandCursor(value:Boolean):void { mUseHandCursor = value; }

--- a/starling/src/starling/display/Sprite.as
+++ b/starling/src/starling/display/Sprite.as
@@ -12,7 +12,7 @@ package starling.display
 {
     import flash.ui.Mouse;
     import flash.ui.MouseCursor;
-    
+
     import starling.core.QuadBatch;
     import starling.core.RenderSupport;
     import starling.core.Starling;
@@ -21,94 +21,94 @@ package starling.display
 
     /** Dispatched on all children when the object is flattened. */
     [Event(name="flatten", type="starling.events.Event")]
-    
+
     /** A Sprite is the most lightweight, non-abstract container class.
      *  <p>Use it as a simple means of grouping objects together in one coordinate system, or
      *  as the base class for custom display objects.</p>
      *
      *  <strong>Flattened Sprites</strong>
-     * 
-     *  <p>The <code>flatten</code>-method allows you to optimize the rendering of static parts of 
+     *
+     *  <p>The <code>flatten</code>-method allows you to optimize the rendering of static parts of
      *  your display list.</p>
      *
-     *  <p>It analyzes the tree of children attached to the sprite and optimizes the rendering calls 
-     *  in a way that makes rendering extremely fast. The speed-up comes at a price, though: you 
-     *  will no longer see any changes in the properties of the children (position, rotation, 
-     *  alpha, etc.). To update the object after changes have happened, simply call 
+     *  <p>It analyzes the tree of children attached to the sprite and optimizes the rendering calls
+     *  in a way that makes rendering extremely fast. The speed-up comes at a price, though: you
+     *  will no longer see any changes in the properties of the children (position, rotation,
+     *  alpha, etc.). To update the object after changes have happened, simply call
      *  <code>flatten</code> again, or <code>unflatten</code> the object.</p>
-     * 
+     *
      *  @see DisplayObject
      *  @see DisplayObjectContainer
-     */  
+     */
     public class Sprite extends DisplayObjectContainer
     {
         private var mFlattenedContents:Vector.<QuadBatch>;
         private var mUseHandCursor:Boolean;
-        
+
         /** Creates an empty sprite. */
         public function Sprite()
         {
             super();
         }
-        
+
         /** @inheritDoc */
         public override function dispose():void
         {
             unflatten();
             super.dispose();
         }
-        
-        /** Indicates if the mouse cursor should transform into a hand while it's over the sprite. 
+
+        /** Indicates if the mouse cursor should transform into a hand while it's over the sprite.
          *  @default false */
         public function get useHandCursor():Boolean { return mUseHandCursor; }
         public function set useHandCursor(value:Boolean):void
         {
             if (value == mUseHandCursor) return;
             mUseHandCursor = value;
-            
+
             if (mUseHandCursor)
                 addEventListener(TouchEvent.TOUCH, onTouch);
             else
                 removeEventListener(TouchEvent.TOUCH, onTouch);
         }
-        
+
         private function onTouch(event:TouchEvent):void
         {
-            Mouse.cursor = event.interactsWith(this) ? MouseCursor.BUTTON : MouseCursor.ARROW;
+            Mouse.cursor = event.interactsWith(this) ? MouseCursor.BUTTON : MouseCursor.AUTO;
         }
-        
+
         /** Optimizes the sprite for optimal rendering performance. Changes in the
          *  children of a flattened sprite will not be displayed any longer. For this to happen,
          *  either call <code>flatten</code> again, or <code>unflatten</code> the sprite. */
         public function flatten():void
         {
             dispatchEventOnChildren(new Event(Event.FLATTEN));
-            
+
             if (mFlattenedContents == null)
             {
                 mFlattenedContents = new <QuadBatch>[];
                 Starling.current.addEventListener(Event.CONTEXT3D_CREATE, onContextCreated);
             }
-            
+
             QuadBatch.compile(this, mFlattenedContents);
         }
-        
+
         /** Removes the rendering optimizations that were created when flattening the sprite.
-         *  Changes to the sprite's children will become immediately visible again. */ 
+         *  Changes to the sprite's children will become immediately visible again. */
         public function unflatten():void
         {
             if (mFlattenedContents)
             {
                 Starling.current.removeEventListener(Event.CONTEXT3D_CREATE, onContextCreated);
                 var numBatches:int = mFlattenedContents.length;
-                
+
                 for (var i:int=0; i<numBatches; ++i)
                     mFlattenedContents[i].dispose();
-                
+
                 mFlattenedContents = null;
             }
         }
-        
+
         private function onContextCreated(event:Event):void
         {
             if (mFlattenedContents)
@@ -117,20 +117,20 @@ package starling.display
                 flatten();
             }
         }
-        
+
         /** Indicates if the sprite was flattened. */
         public function get isFlattened():Boolean { return mFlattenedContents != null; }
-        
+
         /** @inheritDoc */
         public override function render(support:RenderSupport, alpha:Number):void
         {
             if (mFlattenedContents)
             {
                 support.finishQuadBatch();
-                
+
                 alpha *= this.alpha;
                 var numBatches:int = mFlattenedContents.length;
-                
+
                 for (var i:int=0; i<numBatches; ++i)
                     mFlattenedContents[i].render(support.mvpMatrix, alpha);
             }


### PR DESCRIPTION
After setting the handcursor functionality in starling sprites and buttons, using buttonMode on flash displayObjects no longer displays a hand cursor. This fix restores the buttonMode functionality.
