### PR TITLE
Check and protection for if null is passed to TextField constructor

### DIFF
--- a/starling/src/starling/text/TextField.as
+++ b/starling/src/starling/text/TextField.as
@@ -90,7 +90,7 @@ package starling.text
         public function TextField(width:int, height:int, text:String, fontName:String="Verdana",
                                   fontSize:Number=12, color:uint=0x0, bold:Boolean=false)
         {
-            mText = text;
+            mText = text ? text : "";
             mFontSize = fontSize;
             mColor = color;
             mHAlign = HAlign.CENTER;


### PR DESCRIPTION
If null is sent to the text property when creating a TextField, flash will error out when it tries to access the null variable when rendering.  This change checks if the 'text' property is null, and if so sets the internal variable to a blank string instead.
