### PR TITLE
Optimized contains()

### DIFF
--- a/starling/src/starling/display/DisplayObjectContainer.as
+++ b/starling/src/starling/display/DisplayObjectContainer.as
@@ -214,18 +214,11 @@ package starling.display
         /** Determines if a certain object is a child of the container (recursively). */
         public function contains(child:DisplayObject):Boolean
         {
-            if (child == this) return true;
-            
-            var numChildren:int = mChildren.length;
-            for (var i:int=0; i<numChildren; ++i)
+            while(child)
             {
-                var currentChild:DisplayObject = mChildren[i];
-                var currentChildContainer:DisplayObjectContainer = currentChild as DisplayObjectContainer;
-                
-                if (currentChildContainer && currentChildContainer.contains(child)) return true;
-                else if (currentChild == child) return true;
+                if(child == this) return true;
+                child = child.parent;
             }
-            
             return false;
         }
         


### PR DESCRIPTION
I changed contains() to search upwards from the child rather than downwards from the container. Instead of potentially looping over many branches of display objects, it's now a straight line of .parent references up to the stage.
