### PR TITLE
New Event: starling.events.Event.ROOT_CREATED

### DIFF
--- a/starling/src/starling/core/Starling.as
+++ b/starling/src/starling/core/Starling.as
@@ -241,6 +241,7 @@ package starling.core
             var rootObject:DisplayObject = new mRootClass();
             if (rootObject == null) throw new Error("Invalid root class: " + mRootClass);
             mStage.addChild(rootObject);
+            dispatchEvent(new starling.events.Event(starling.events.Event.ROOT_CREATED));
         }
         
         private function updateViewPort():void

--- a/starling/src/starling/events/Event.as
+++ b/starling/src/starling/events/Event.as
@@ -56,6 +56,8 @@ package starling.events
         public static const CONTEXT3D_CREATE:String = "context3DCreate";
         /** Event type for an animated object that requests to be removed from the juggler. */
         public static const REMOVE_FROM_JUGGLER:String = "removeFromJuggler";
+        /** Event type that indicates that the root DisplayObject has been created. */
+        public static const ROOT_CREATED:String = "rootCreated";
         
         private var mTarget:EventDispatcher;
         private var mCurrentTarget:EventDispatcher;


### PR DESCRIPTION
Since Starling is founded on the instantiation of a RootClass, it's important for listeners outside Starling to know when the instance of that RootClass is available. And because Starling both creates and adds that instance to stage, there's no determinative way to know this has occurred at present. I've added a dispatch from Starling.initializeRoot(). This Event occurs after rootObject is added to Stage, so it effectively informs listeners that Starling is safe to interact with.

Arguably there should be two Events: one when the rootObject is created and a second when rootObject is added to stage. This would let a listener perform actions between those two Events. I'll leave it to you to determine if the extra event is useful, but I'm reasonably certain that at least the code I've provided is beneficial.
