### PR TITLE
Added native filter support for Starling's TextField

### DIFF
--- a/starling/src/starling/text/TextField.as
+++ b/starling/src/starling/text/TextField.as
@@ -166,6 +166,7 @@ package starling.text
             sNativeTextField.wordWrap = true;            
             sNativeTextField.text = mText;
             sNativeTextField.embedFonts = true;
+            sNativeTextField.filters = mNativeFilters;
             
             // we try embedded fonts first, non-embedded fonts are just a fallback
             if (sNativeTextField.textWidth == 0.0 || sNativeTextField.textHeight == 0.0)
@@ -173,9 +174,6 @@ package starling.text
             
             if (mAutoScale)
                 autoScaleNativeTextField(sNativeTextField);
-
-            if (mNativeFilters != null)
-                sNativeTextField.filters = mNativeFilters;
             
             var textWidth:Number  = sNativeTextField.textWidth;
             var textHeight:Number = sNativeTextField.textHeight;


### PR DESCRIPTION
Most other native TF properties had a mapping but filters didn't. My understanding is that Starling will probably implement a filters system similar to native at some point anyway - but that will be applicable to all DOs. I think TF's can be an exception as they are already being rendered using native anyway (bitmap excluded), so I have added a 'nativeFilters' property accordingly.

This gives a nice way to quickly get the same effects we had during design time in the IDE - something that's often critical on mobile devices for readability anyway. Glow Filters and Drop Shadows in particular are great for readability.

Any applied filters that increase the size (i.e. Glow Filters) would still need room inside the TF to render - but as this also applies to specifying the text size anyway (autoScale aside) I don't think this is an issue.
