### PR TITLE
small getNextPowerOfTwo improvement

### DIFF
--- a/starling/src/starling/utils/getNextPowerOfTwo.as
+++ b/starling/src/starling/utils/getNextPowerOfTwo.as
@@ -13,7 +13,7 @@ package starling.utils
     /** Returns the next power of two that is equal to or bigger than the specified number. */
     public function getNextPowerOfTwo(number:int):int
     {
-        var result:int = 2;
+        var result:int = 1;
         while (result < number) result <<= 1;
         return result;   
     }


### PR DESCRIPTION
Since it's called twice per new Texture creation, it makes sense to optimize it, even if optimization is not huge:) All we want starling to be faster and faster, don't we?$)
