### PR TITLE
onDemand getNextPowerOfTwo

### DIFF
--- a/starling/src/starling/textures/Texture.as
+++ b/starling/src/starling/textures/Texture.as
@@ -123,8 +123,8 @@ package starling.textures
         {
             var origWidth:int = data.width;
             var origHeight:int = data.height;
-            var legalWidth:int  = getNextPowerOfTwo(data.width);
-            var legalHeight:int = getNextPowerOfTwo(data.height);
+            var legalWidth:int  = (origWidth & (origWidth - 1)) ? getNextPowerOfTwo(origWidth) : origWidth;
+            var legalHeight:int = (origHeight & (origHeight - 1)) ? getNextPowerOfTwo(origHeight) : origHeight;
             var context:Context3D = Starling.context;
             var potData:BitmapData;
             


### PR DESCRIPTION
I think starling should not call getNextPowerOfTwo if it's not necessary:)

Note:
to check power of two i prever to use this algorithm:
http://en.wikipedia.org/wiki/Power_of_two#Fast_algorithm_to_check_if_a_positive_number_is_a_power_of_two
