### PR TITLE
TouchEvent Pooling

### DIFF
--- a/starling/src/starling/core/TouchProcessor.as
+++ b/starling/src/starling/core/TouchProcessor.as
@@ -116,9 +116,14 @@ package starling.core
                 // if the target of a hovering touch changed, we dispatch an event to the previous
                 // target to notify it that it's no longer being hovered over.
                 for each (var touchData:Object in sHoveringTouchData)
+                {
                     if (touchData.touch.target != touchData.target)
-                        touchData.target.dispatchEvent(new TouchEvent(
-                            TouchEvent.TOUCH, mCurrentTouches, mShiftDown, mCtrlDown));
+                    {
+                        var event:TouchEvent = TouchEvent.fromPool(TouchEvent.TOUCH, mCurrentTouches, mShiftDown, mCtrlDown)
+                        touchData.target.dispatchEvent(event);
+                        TouchEvent.toPool(event);
+                    }
+                }
                 
                 // dispatch events
                 for each (touchID in sProcessedTouchIDs)
@@ -126,8 +131,11 @@ package starling.core
                     touch = getCurrentTouch(touchID);
                     
                     if (touch.target)
-                        touch.target.dispatchEvent(new TouchEvent(TouchEvent.TOUCH, mCurrentTouches,
-                                                                  mShiftDown, mCtrlDown));
+                    {
+                        event = TouchEvent.fromPool(TouchEvent.TOUCH, mCurrentTouches, mShiftDown, mCtrlDown)
+                        touch.target.dispatchEvent(event);
+                        TouchEvent.toPool(event);
+                    }
                 }
                 
                 // remove ended touches

--- a/starling/src/starling/events/Event.as
+++ b/starling/src/starling/events/Event.as
@@ -64,13 +64,13 @@ package starling.events
         
         private static var sEventPool:Vector.<Event> = new <Event>[];
         
-        private var mTarget:EventDispatcher;
-        private var mCurrentTarget:EventDispatcher;
-        private var mType:String;
-        private var mBubbles:Boolean;
-        private var mStopsPropagation:Boolean;
-        private var mStopsImmediatePropagation:Boolean;
-        private var mData:Object;
+        protected var mTarget:EventDispatcher;
+        protected var mCurrentTarget:EventDispatcher;
+        protected var mType:String;
+        protected var mBubbles:Boolean;
+        protected var mStopsPropagation:Boolean;
+        protected var mStopsImmediatePropagation:Boolean;
+        protected var mData:Object;
         
         /** Creates an event object that can be passed to listeners. */
         public function Event(type:String, bubbles:Boolean=false, data:Object=null)


### PR DESCRIPTION
I have updated TouchProcessor to use pooled touch events. The pooling is exposed as static functions on TouchEvent. I tried to keep it very similar to the starling.events.Event implementation of pooling. The main difference is that doesn't tie into dispatchEventWith() in any way. TouchProcessor directly calls fromPool() and toPool().

I'm seeing a small FPS improvement when scrolling a Foxhole list on my iPad 1. It's only about 1-3 FPS, but I tested the pooled implementation a number of times to be sure, and it is consistently better than the old implementation with TouchEvents that are not pooled.