### PR TITLE
Add get modelViewMatrix function to RenderSupport

### DIFF
--- a/starling/src/starling/core/RenderSupport.as
+++ b/starling/src/starling/core/RenderSupport.as
@@ -132,6 +132,14 @@ package starling.core
             mMatrixStackSize = 0;
             loadIdentity();
         }
+		
+		/** Calculates the product of modelview without projection matrix.
+		 *  CAUTION: Don't save a reference to this object! Each call returns the same instance. */
+		public function get modelViewMatrix():Matrix
+		{
+			mMvpMatrix.copyFrom(mModelViewMatrix);
+			return mMvpMatrix;
+		}
         
         /** Calculates the product of modelview and projection matrix. 
          *  CAUTION: Don't save a reference to this object! Each call returns the same instance. */


### PR DESCRIPTION
This is cpu speed safer, when we need to do something like set masking of some sprite. Old school way is to use localToGlobal to convert current sprite x to global x but it takes more cpu and ram usage.
Adding this will also helps to get global rotation, scale, skew of current displayObject without any further effort.
