### PR TITLE
Added option to ignore mipmaps when loading ATF data

### DIFF
--- a/starling/src/starling/textures/Texture.as
+++ b/starling/src/starling/textures/Texture.as
@@ -163,7 +163,7 @@ package starling.textures
         
         /** Creates a texture from the compressed ATF format. 
          *  Beware: you must not dispose 'data' if Starling should handle a lost device context. */ 
-        public static function fromAtfData(data:ByteArray, scale:Number=1):Texture
+        public static function fromAtfData(data:ByteArray, scale:Number=1, ignoreMipMaps:Boolean = false):Texture
         {
             var context:Context3D = Starling.context;
             if (context == null) throw new MissingContextError();
@@ -175,7 +175,7 @@ package starling.textures
             uploadAtfData(nativeTexture, data);
             
             var concreteTexture:ConcreteTexture = new ConcreteTexture(nativeTexture, atfData.format, 
-                atfData.width, atfData.height, atfData.numTextures > 1, false, false, scale);
+                atfData.width, atfData.height, atfData.numTextures > 1 && !ignoreMipMaps, false, false, scale);
             
             if (Starling.handleLostContext) 
                 concreteTexture.restoreOnLostContext(atfData);


### PR DESCRIPTION
Simple change to give an option to ignore mipmaps on ATFs. DXT5 textures have to have mip maps. The current ATF tool has an option to generate blank mip maps which compress well, but the default implementation will still try to use them if a sprite is scaled (which gives an empty sprite). This option allows us to get around this.
