### PR TITLE
Fix Demo source paths in Flex Builder

### DIFF
--- a/samples/demo_mobile/.actionScriptProperties
+++ b/samples/demo_mobile/.actionScriptProperties
@@ -2,9 +2,9 @@
 <actionScriptProperties analytics="false" mainApplicationPath="Startup_Mobile.as" projectUUID="f842483a-86bc-45da-b1d8-d4a7528d15a5" version="11">
   <compiler additionalCompilerArguments="-locale en_US" advancedTelemetry="false" autoRSLOrdering="true" copyDependentFiles="true" fteInMXComponents="false" generateAccessible="false" htmlExpressInstall="true" htmlGenerate="false" htmlHistoryManagement="false" htmlPlayerVersionCheck="true" includeNetmonSwc="false" outputFolderPath="bin-debug" removeUnusedRSL="true" sourceFolderPath="src" strict="true" targetPlayerVersion="0.0.0" useApolloConfig="true" useDebugRSLSwfs="true" useFlashSDK="true" verifyDigests="true" warn="true">
     <compilerSourcePath>
-      <compilerSourcePathEntry kind="1" linkType="1" path="/Users/redge/Development/starling/samples/demo/src"/>
-      <compilerSourcePathEntry kind="1" linkType="1" path="/Users/redge/Development/starling/samples/demo/system"/>
-      <compilerSourcePathEntry kind="1" linkType="1" path="/Users/redge/Development/starling/samples/demo/assets"/>
+      <compilerSourcePathEntry kind="1" linkType="1" path="${STARLING_FRAMEWORK}/samples/demo/src"/>
+      <compilerSourcePathEntry kind="1" linkType="1" path="${STARLING_FRAMEWORK}/samples/demo/system"/>
+      <compilerSourcePathEntry kind="1" linkType="1" path="${STARLING_FRAMEWORK}/samples/demo/assets"/>
     </compilerSourcePath>
     <libraryPath defaultLinkType="0">
       <libraryPathEntry kind="4" path="">

--- a/samples/demo_mobile/.project
+++ b/samples/demo_mobile/.project
@@ -27,17 +27,17 @@
 		<link>
 			<name>[source path] assets</name>
 			<type>2</type>
-			<location>/Users/redge/Development/starling/samples/demo/assets</location>
+			<locationURI>STARLING_FRAMEWORK/samples/demo/assets</locationURI>
 		</link>
 		<link>
 			<name>[source path] src</name>
 			<type>2</type>
-			<location>/Users/redge/Development/starling/samples/demo/src</location>
+			<locationURI>STARLING_FRAMEWORK/samples/demo/src</locationURI>
 		</link>
 		<link>
 			<name>[source path] system</name>
 			<type>2</type>
-			<location>/Users/redge/Development/starling/samples/demo/system</location>
+			<locationURI>STARLING_FRAMEWORK/samples/demo/system</locationURI>
 		</link>
 	</linkedResources>
 </projectDescription>

--- a/samples/demo_web/.actionScriptProperties
+++ b/samples/demo_web/.actionScriptProperties
@@ -2,7 +2,7 @@
 <actionScriptProperties analytics="false" mainApplicationPath="Preloader.as" projectUUID="9573455a-0df5-4e91-9270-ad108510699f" version="11">
   <compiler additionalCompilerArguments="-locale en_US&#10;-frame StartupFrame Startup_Web&#10;-inline" advancedTelemetry="false" autoRSLOrdering="true" copyDependentFiles="true" fteInMXComponents="false" generateAccessible="false" htmlExpressInstall="true" htmlGenerate="false" htmlHistoryManagement="true" htmlPlayerVersionCheck="true" includeNetmonSwc="false" outputFolderPath="bin-debug" removeUnusedRSL="true" sourceFolderPath="src" strict="true" targetPlayerVersion="0.0.0" useApolloConfig="false" useDebugRSLSwfs="true" useFlashSDK="true" verifyDigests="true" warn="true">
     <compilerSourcePath>
-      <compilerSourcePathEntry kind="1" linkType="1" path="/Users/redge/Development/starling/samples/demo/src"/>
+      <compilerSourcePathEntry kind="1" linkType="1" path="${STARLING_FRAMEWORK}/samples/demo/src"/>
     </compilerSourcePath>
     <libraryPath defaultLinkType="0">
       <libraryPathEntry kind="4" path="">

--- a/samples/demo_web/.project
+++ b/samples/demo_web/.project
@@ -19,7 +19,7 @@
 		<link>
 			<name>[source path] src</name>
 			<type>2</type>
-			<location>/Users/redge/Development/starling/samples/demo/src</location>
+			<locationURI>STARLING_FRAMEWORK/samples/demo/src</locationURI>
 		</link>
 	</linkedResources>
 </projectDescription>


### PR DESCRIPTION
This fixes the Flash Builder demo projects, which currently refer to source paths on another developer's machine ("/Users/redge/Development/starling"). I changed the paths so that they're relative to an Eclipse workspace path variable (STARLING_FRAMEWORK).

If this change is accepted, users will have to add this path variable to Flash Builder (Preferences > General > Workspace > Linked Resources. Add a new path variable called STARLING_FRAMEWORK that points to the root Starling-Framework directory).
