### PR TITLE
Adding .pex support for AssetManager class

### DIFF
--- a/samples/demo/src/utils/AssetManager.as
+++ b/samples/demo/src/utils/AssetManager.as
@@ -38,7 +38,7 @@ package utils
     public class AssetManager
     {
         private const SUPPORTED_EXTENSIONS:Vector.<String> = 
-            new <String>["png", "jpg", "jpeg", "atf", "mp3", "xml", "fnt"]; 
+            new <String>["png", "jpg", "jpeg", "atf", "mp3", "xml", "fnt", "pex"]; 
         
         private var mScaleFactor:Number;
         private var mGenerateMipmaps:Boolean;
@@ -48,6 +48,7 @@ package utils
         private var mTextures:Dictionary;
         private var mAtlases:Dictionary;
         private var mSounds:Dictionary;
+		private var mParticleConfigs:Dictionary;
         
         /** helper objects */
         private var sNames:Vector.<String> = new <String>[];
@@ -63,6 +64,7 @@ package utils
             mTextures = new Dictionary();
             mAtlases = new Dictionary();
             mSounds = new Dictionary();
+			mParticleConfigs = new Dictionary();
         }
         
         /** Disposes all contained textures. */
@@ -157,6 +159,12 @@ package utils
             else 
                 return null;
         }
+
+		/** Returns an XML Particle config with a certain name. */
+		public function getParticleConfig(name:String):XML
+		{
+			return mParticleConfigs[name];
+		}
         
         // direct adding
         
@@ -192,6 +200,17 @@ package utils
             else
                 mSounds[name] = sound;
         }
+
+		/** Register a Particle config a certain name. It will be available right away. */
+		public function addParticleConfig(name:String, config:XML):void
+		{
+			log("Adding particle config '" + name + "'");
+			
+			if (name in mParticleConfigs)
+				throw new Error("Duplicate particle config name: " + name);
+			else
+				mParticleConfigs[name] = config;
+		}
         
         // removing
         
@@ -218,6 +237,12 @@ package utils
         {
             delete mSounds[name];
         }
+
+		/** Removes a certain particle config. */
+		public function removeParticleConfig(name:String):void
+		{
+			delete mParticleConfigs[name];
+		}
         
         /** Removes assets of all types and empties the queue. */
         public function purge():void
@@ -232,6 +257,7 @@ package utils
             mTextures = new Dictionary();
             mAtlases = new Dictionary();
             mSounds = new Dictionary();
+			mParticleConfigs = new Dictionary();
         }
         
         // queued adding
@@ -382,6 +408,11 @@ package utils
                         TextField.registerBitmapFont(new BitmapFont(fontTexture, xml));
                         removeTexture(name, false);
                     }
+					else if (rootNode == "particleEmitterConfig")
+					{
+						name = getName(xml.texture.@name.toString());
+						addParticleConfig(name, xml);
+					}
                     else
                         throw new Error("XML contents not recognized: " + rootNode);
                 }
@@ -461,6 +492,7 @@ package utils
                         break;
                     case "fnt":
                     case "xml":
+					case "pex":
                         xmls.push(new XML(bytes));
                         onComplete();
                         break;


### PR DESCRIPTION
Hi,
i've added .pex support without that AssetManager needs to know the Particle-System extension.
In practice just put your particle assets to assets/particles/{0}x directories and enque it with
assets.enqueue(...,
              appDir.resolvePath(formatString("particles/{0}x", scaleFactor))
              );

In the class that wants to add a particle extension just write
_fullExplosion = new PDParticleSystem(Game.assets.getParticleConfig("YourExplosion"), Game.assets.getTexture("YourExplosion"));
addChild(_fullExplosion);

and it works. No embedding of textures or .pex files needed anymore.

I hope that you can use it.
Best regards
Valentin
