### PR TITLE
Allow custom formatting for TextField

### DIFF
--- a/starling/src/starling/text/TextField.as
+++ b/starling/src/starling/text/TextField.as
@@ -215,11 +215,11 @@ package starling.text
             }
         }
 
-    /** formatText is called immediately before the text is rendered. The intent of formatText
-     *  is to be overridden in a subclass, so that you can provide custom formatting for TextField.
-     *  <code>textField</code> is the flash.text.TextField object that you can specially format;
-     *  <code>textFormat</code> is the default TextFormat for <code>textField</code>.
-     */
+        /** formatText is called immediately before the text is rendered. The intent of formatText
+         *  is to be overridden in a subclass, so that you can provide custom formatting for TextField.
+         *  <code>textField</code> is the flash.text.TextField object that you can specially format;
+         *  <code>textFormat</code> is the default TextFormat for <code>textField</code>.
+         */
         protected function formatText(textField:flash.text.TextField, textFormat:TextFormat):void {}
 
         private function autoScaleNativeTextField(textField:flash.text.TextField):void


### PR DESCRIPTION
As I discussed in #262, this adds a `formatText` method onto `TextField`. It's super simple. 

I wrote a little repository to show what this can do [here](https://github.com/johnfn/RedGreenText). The meat is [this](https://github.com/johnfn/RedGreenText/blob/master/RedGreenText.as) file, which overrides `TextField` to render the text in a cute way.
