### PR TITLE
Separate touch processing from dispatching

### DIFF
--- a/starling/src/starling/core/Starling.as
+++ b/starling/src/starling/core/Starling.as
@@ -42,6 +42,8 @@ package starling.core
     import starling.display.Stage;
     import starling.events.EventDispatcher;
     import starling.events.ResizeEvent;
+    import starling.events.Touch;
+    import starling.events.TouchHandler;
     import starling.events.TouchPhase;
     import starling.utils.HAlign;
     import starling.utils.VAlign;
@@ -811,7 +813,11 @@ package starling.core
         /** The Context3D profile as requested in the constructor. Beware that if you are 
          *  using a shared context, this might not be accurate. */
         public function get profile():String { return mProfile; }
-        
+
+        /** The TouchHandler. All Touch input is processed by Starling and passed to the handler. */
+        public function get touchHandler():TouchHandler { return mTouchProcessor.touchHandler; }
+        public function set touchHandler(value:TouchHandler):void { mTouchProcessor.touchHandler = value; }
+
         // static properties
         
         /** The currently active Starling instance. */

--- a/starling/src/starling/core/TouchProcessor.as
+++ b/starling/src/starling/core/TouchProcessor.as
@@ -10,13 +10,13 @@
 
 package starling.core
 {
-    import flash.geom.Point;
     import flash.utils.getDefinitionByName;
     
     import starling.display.Stage;
     import starling.events.KeyboardEvent;
     import starling.events.Touch;
-    import starling.events.TouchEvent;
+    import starling.events.TouchDispatcher;
+    import starling.events.TouchHandler;
     import starling.events.TouchPhase;
 
     use namespace starling_internal;
@@ -32,6 +32,8 @@ package starling.core
         private var mStage:Stage;
         private var mElapsedTime:Number;
         private var mTouchMarker:TouchMarker;
+
+        private var mTouchHandler:TouchHandler;
         
         private var mCurrentTouches:Vector.<Touch>;
         private var mQueue:Vector.<Array>;
@@ -42,8 +44,7 @@ package starling.core
         
         /** Helper objects. */
         private static var sProcessedTouchIDs:Vector.<int> = new <int>[];
-        private static var sHoveringTouchData:Vector.<Object> = new <Object>[];
-        
+
         public function TouchProcessor(stage:Stage)
         {
             mStage = stage;
@@ -51,7 +52,10 @@ package starling.core
             mCurrentTouches = new <Touch>[];
             mQueue = new <Array>[];
             mLastTaps = new <Touch>[];
-            
+
+            // install the default touch handler
+            mTouchHandler = new TouchDispatcher(stage);
+
             mStage.addEventListener(KeyboardEvent.KEY_DOWN, onKey);
             mStage.addEventListener(KeyboardEvent.KEY_UP,   onKey);
             monitorInterruptions(true);
@@ -63,6 +67,7 @@ package starling.core
             mStage.removeEventListener(KeyboardEvent.KEY_DOWN, onKey);
             mStage.removeEventListener(KeyboardEvent.KEY_UP,   onKey);
             if (mTouchMarker) mTouchMarker.dispose();
+            if (mTouchHandler) mTouchHandler.dispose();
         }
         
         public function advanceTime(passedTime:Number):void
@@ -83,48 +88,32 @@ package starling.core
             
             while (mQueue.length > 0)
             {
-                sProcessedTouchIDs.length = sHoveringTouchData.length = 0;
-                
-                // set touches that were new or moving to phase 'stationary'
+                sProcessedTouchIDs.length = 0;
+
+                // Set touches that were new or moving to phase 'stationary'.
+                // Moving into the STATIONARY state doesn't generate touch events, so we don't
+                // set the 'updated' flag on these touches.
                 for each (touch in mCurrentTouches)
+                {
+                    touch.setUpdated(false);
                     if (touch.phase == TouchPhase.BEGAN || touch.phase == TouchPhase.MOVED)
                         touch.setPhase(TouchPhase.STATIONARY);
-                
+                }
+
                 // process new touches, but each ID only once
                 while (mQueue.length > 0 && 
                     sProcessedTouchIDs.indexOf(mQueue[mQueue.length-1][0]) == -1)
                 {
                     var touchArgs:Array = mQueue.pop();
-                    touchID = touchArgs[0] as int;
-                    touch = getCurrentTouch(touchID);
-                    
-                    // hovering touches need special handling (see below)
-                    if (touch && touch.phase == TouchPhase.HOVER && touch.target)
-                        sHoveringTouchData.push({ 
-                            touch: touch, 
-                            target: touch.target, 
-                            bubbleChain: touch.bubbleChain 
-                        });
-                    
-                    processTouch.apply(this, touchArgs);
-                    sProcessedTouchIDs.push(touchID);
+                    touch = processTouch.apply(this, touchArgs);
+                    sProcessedTouchIDs.push(touch.id);
+                    touch.setUpdated(true);
                 }
-                
-                // the same touch event will be dispatched to all targets; 
-                // the 'dispatch' method will make sure each bubble target is visited only once.
-                var touchEvent:TouchEvent = 
-                    new TouchEvent(TouchEvent.TOUCH, mCurrentTouches, mShiftDown, mCtrlDown); 
-                
-                // if the target of a hovering touch changed, we dispatch the event to the previous
-                // target to notify it that it's no longer being hovered over.
-                for each (var touchData:Object in sHoveringTouchData)
-                    if (touchData.touch.target != touchData.target)
-                        touchEvent.dispatch(touchData.bubbleChain);
-                
-                // dispatch events
-                for each (touchID in sProcessedTouchIDs)
-                    getCurrentTouch(touchID).dispatchEvent(touchEvent);
-                
+
+                // hand the newly-processed touches to the touch handler
+                if (mTouchHandler)
+                    mTouchHandler.handleTouches(mCurrentTouches);
+
                 // remove ended touches
                 for (i=mCurrentTouches.length-1; i>=0; --i)
                     if (mCurrentTouches[i].phase == TouchPhase.ENDED)
@@ -175,14 +164,13 @@ package starling.core
         }
         
         private function processTouch(touchID:int, phase:String, globalX:Number, globalY:Number,
-                                      pressure:Number=1.0, width:Number=1.0, height:Number=1.0):void
+                                      pressure:Number=1.0, width:Number=1.0, height:Number=1.0):Touch
         {
-            var position:Point = new Point(globalX, globalY);
             var touch:Touch = getCurrentTouch(touchID);
             
             if (touch == null)
             {
-                touch = new Touch(touchID, globalX, globalY, phase, null);
+                touch = new Touch(touchID, globalX, globalY, phase);
                 addCurrentTouch(touch);
             }
             
@@ -191,12 +179,11 @@ package starling.core
             touch.setTimestamp(mElapsedTime);
             touch.setPressure(pressure);
             touch.setSize(width, height);
-            
-            if (phase == TouchPhase.HOVER || phase == TouchPhase.BEGAN)
-                touch.setTarget(mStage.hitTest(position, true));
-            
+
             if (phase == TouchPhase.BEGAN)
                 processTap(touch);
+
+            return touch;
         }
         
         private function onKey(event:KeyboardEvent):void
@@ -297,7 +284,10 @@ package starling.core
                 mTouchMarker = null;
             }
         }
-        
+
+        public function get touchHandler():TouchHandler { return mTouchHandler; }
+        public function set touchHandler(value:TouchHandler):void { mTouchHandler = value; }
+
         // interruption handling
         
         private function monitorInterruptions(enable:Boolean):void
@@ -320,25 +310,23 @@ package starling.core
         
         private function onInterruption(event:Object):void
         {
-            var touch:Touch;
-            
-            // abort touches
-            for each (touch in mCurrentTouches)
+            if (mCurrentTouches.length > 0 && mTouchHandler != null)
             {
-                if (touch.phase == TouchPhase.BEGAN || touch.phase == TouchPhase.MOVED ||
-                    touch.phase == TouchPhase.STATIONARY)
+                // abort touches
+                for each (var touch:Touch in mCurrentTouches)
                 {
-                    touch.setPhase(TouchPhase.ENDED);
+                    if (touch.phase == TouchPhase.BEGAN || touch.phase == TouchPhase.MOVED ||
+                        touch.phase == TouchPhase.STATIONARY)
+                    {
+                        touch.setPhase(TouchPhase.ENDED);
+                        touch.setUpdated(true);
+                    }
                 }
+
+                // update the touch handler
+                mTouchHandler.handleTouches(mCurrentTouches);
             }
-            
-            // dispatch events
-            var touchEvent:TouchEvent = 
-                new TouchEvent(TouchEvent.TOUCH, mCurrentTouches, mShiftDown, mCtrlDown);
-            
-            for each (touch in mCurrentTouches)
-                touch.dispatchEvent(touchEvent);
-            
+
             // purge touches
             mCurrentTouches.length = 0;
         }

--- a/starling/src/starling/events/Touch.as
+++ b/starling/src/starling/events/Touch.as
@@ -52,23 +52,22 @@ package starling.events
         private var mPressure:Number;
         private var mWidth:Number;
         private var mHeight:Number;
+        private var mUpdated:Boolean;
         private var mBubbleChain:Vector.<EventDispatcher>;
         
         /** Helper object. */
         private static var sHelperMatrix:Matrix = new Matrix();
         
         /** Creates a new Touch object. */
-        public function Touch(id:int, globalX:Number, globalY:Number, phase:String, target:DisplayObject)
+        public function Touch(id:int, globalX:Number, globalY:Number, phase:String)
         {
             mID = id;
             mGlobalX = mPreviousGlobalX = globalX;
             mGlobalY = mPreviousGlobalY = globalY;
             mTapCount = 0;
             mPhase = phase;
-            mTarget = target;
             mPressure = mWidth = mHeight = 1.0;
             mBubbleChain = new <EventDispatcher>[];
-            updateBubbleChain();
         }
         
         /** Converts the current location of a touch to the local coordinate system of a display 
@@ -121,7 +120,7 @@ package starling.events
         /** Creates a clone of the Touch object. */
         public function clone():Touch
         {
-            var clone:Touch = new Touch(mID, mGlobalX, mGlobalY, mPhase, mTarget);
+            var clone:Touch = new Touch(mID, mGlobalX, mGlobalY, mPhase);
             clone.mPreviousGlobalX = mPreviousGlobalX;
             clone.mPreviousGlobalY = mPreviousGlobalY;
             clone.mTapCount = mTapCount;
@@ -129,6 +128,7 @@ package starling.events
             clone.mPressure = mPressure;
             clone.mWidth = mWidth;
             clone.mHeight = mHeight;
+            clone.setTarget(mTarget);
             return clone;
         }
         
@@ -194,7 +194,9 @@ package starling.events
         /** Height of the contact area. 
          *  If the device does not support detecting the pressure, the value is 1.0. */
         public function get height():Number { return mHeight; }
-        
+
+        /** True if this is a new Touch or an existing Touch that was just updated */
+        public function get updated():Boolean { return mUpdated; }
         // internal methods
         
         /** @private 
@@ -212,10 +214,13 @@ package starling.events
         }
         
         /** @private */
-        starling_internal function setTarget(value:DisplayObject):void 
-        { 
-            mTarget = value;
-            updateBubbleChain();
+        starling_internal function setTarget(value:DisplayObject):void
+        {
+            if (mTarget != value)
+            {
+                mTarget = value;
+                updateBubbleChain();
+            }
         }
         
         /** @private */
@@ -245,5 +250,8 @@ package starling.events
         
         /** @private */
         starling_internal function setPressure(value:Number):void { mPressure = value; }
+
+        /** @private */
+        starling_internal function setUpdated(value:Boolean):void { mUpdated = value; }
     }
 }

--- a/starling/src/starling/events/TouchDispatcher.as
+++ b/starling/src/starling/events/TouchDispatcher.as
@@ -1,0 +1,98 @@
+// =================================================================================================
+//
+//    Starling Framework
+//    Copyright 2011 Gamua OG. All Rights Reserved.
+//
+//    This program is free software. You can redistribute and/or modify it
+//    in accordance with the terms of the accompanying license agreement.
+//
+// =================================================================================================
+
+package starling.events
+{
+    import flash.geom.Point;
+
+    import starling.core.starling_internal;
+    import starling.display.DisplayObjectContainer;
+    import starling.display.Stage;
+
+    use namespace starling_internal;
+
+    /** Starling's default TouchHandler implementation. Dispatches TouchEvents on the display list
+     * in reponse to touch input. */
+    public class TouchDispatcher implements TouchHandler
+    {
+        private var mRoot:DisplayObjectContainer;
+        private var mStage:Stage;
+
+        private var mShiftDown:Boolean = false;
+        private var mCtrlDown:Boolean = false;
+
+        /** Helper object */
+        private static var sHoveringTouchData:Vector.<Object> = new <Object>[];
+
+        /** Constructs a new TouchDispatcher with the given DisplayObjectContainer root. */
+        public function TouchDispatcher(root:DisplayObjectContainer)
+        {
+            mRoot = root;
+            mStage = root.stage;
+            if (mStage == null)
+                throw new ArgumentError("root must be added to the stage");
+
+            mStage.addEventListener(KeyboardEvent.KEY_DOWN, onKey);
+            mStage.addEventListener(KeyboardEvent.KEY_UP,   onKey);
+        }
+
+        public function dispose():void
+        {
+            mStage.removeEventListener(KeyboardEvent.KEY_DOWN, onKey);
+            mStage.removeEventListener(KeyboardEvent.KEY_UP,   onKey);
+        }
+
+        public function handleTouches(touches:Vector.<Touch>):void
+        {
+            sHoveringTouchData.length = 0;
+            var touch:Touch;
+
+            // the same touch event will be dispatched to all targets;
+            // the 'dispatch' method will make sure each bubble target is visited only once.
+            var touchEvent:TouchEvent = new TouchEvent(TouchEvent.TOUCH, touches, mShiftDown, mCtrlDown);
+
+            // hit test our updated touches
+            for each (touch in touches)
+            {
+                if (!touch.updated) continue;
+
+                // hovering touches need special handling (see below)
+                if (touch.phase == TouchPhase.HOVER && touch.target)
+                    sHoveringTouchData.push({
+                        touch: touch,
+                        target: touch.target,
+                        bubbleChain: touch.bubbleChain
+                    });
+
+                if (touch.phase == TouchPhase.HOVER || touch.phase == TouchPhase.BEGAN)
+                    touch.setTarget(mRoot.hitTest(new Point(touch.globalX, touch.globalY), true));
+            }
+
+            // if the target of a hovering touch changed, we dispatch the event to the previous
+            // target to notify it that it's no longer being hovered over.
+            for each (var touchData:Object in sHoveringTouchData)
+                if (touchData.touch.target != touchData.target)
+                    touchEvent.dispatch(touchData.bubbleChain);
+
+            // dispatch events for the rest of our updated touches
+            for each (touch in touches)
+                if (touch.updated)
+                    touch.dispatchEvent(touchEvent);
+        }
+
+        private function onKey(event:KeyboardEvent):void
+        {
+            if (event.keyCode == 17 || event.keyCode == 15) // ctrl or cmd key
+                mCtrlDown = event.type == KeyboardEvent.KEY_DOWN;
+            else if (event.keyCode == 16)
+                mShiftDown = event.type == KeyboardEvent.KEY_DOWN;
+        }
+    }
+}

--- a/starling/src/starling/events/TouchHandler.as
+++ b/starling/src/starling/events/TouchHandler.as
@@ -1,0 +1,25 @@
+// =================================================================================================
+//
+//    Starling Framework
+//    Copyright 2011 Gamua OG. All Rights Reserved.
+//
+//    This program is free software. You can redistribute and/or modify it
+//    in accordance with the terms of the accompanying license agreement.
+//
+// =================================================================================================
+
+package starling.events {
+
+    /** An interface that allows for low-level handling of Touch input. User code can install
+     * a custom TouchHandler via Starling.touchHandler */
+    public interface TouchHandler
+    {
+        /** Handle touch input. 'touches' is a list of *all* current touches. Touches that were
+         * just created or updated as a result of new input will have their 'updated' properties
+         * set to true.  */
+        function handleTouches(touches:Vector.<Touch>):void;
+
+        /** Perform any necessary cleanup */
+        function dispose():void;
+    }
+}


### PR DESCRIPTION
(Re-created to cleanly merge with the latest starling HEAD)

Hey Daniel, here's the pull request with my minor refactor of TouchProcessor. This essentially breaks TouchProcessor into two different classes: TouchProcessor, which creates Touch objects, and TouchDispatcher, which implements a new TouchHandler interface and does the TouchEvent creation and dispatching.

Starling's default behavior and API are unchanged. There's a new property on the Starling class, 'touchHandler', which allows user code to install its own TouchHandler object and perform custom Touch input processing.

I've tested this code against the Starling demos and unit tests.
