### PR TITLE
Scissor rect support for DisplayObjectContainer

### DIFF
--- a/starling/src/starling/textures/RenderTexture.as
+++ b/starling/src/starling/textures/RenderTexture.as
@@ -163,7 +163,7 @@ package starling.textures
             // limit drawing to relevant area
             sScissorRect.setTo(0, 0, mActiveTexture.nativeWidth, mActiveTexture.nativeHeight);
 
-            mSupport.scissorRectangle = sScissorRect;
+            mSupport.pushScissorRect(sScissorRect);
             mSupport.renderTarget = mActiveTexture;
             mSupport.clear();
             
@@ -187,7 +187,7 @@ package starling.textures
                 mSupport.finishQuadBatch();
                 mSupport.nextFrame();
                 mSupport.renderTarget = null;
-                mSupport.scissorRectangle = null;
+                mSupport.popScissorRect();
             }
         }
         


### PR DESCRIPTION
Hey Daniel,

I've ported my similar pull request from Sparrow (https://github.com/PrimaryFeather/Sparrow-Framework/pull/1070) to Starling. Basically, this adds a scissorRect getter/setter to DisplayObjectContainer. It shouldn't add any CPU overhead for code that doesn't use it.

(This also fixes a bug in the existing Starling scissor-rect code: RenderSupport.finishQuadBatch() needs to be called when the scissor rect changes)
