### PR TITLE
Fix 'Sprite.clipRect = null'

### DIFF
--- a/starling/src/starling/display/Sprite.as
+++ b/starling/src/starling/display/Sprite.as
@@ -116,8 +116,8 @@ package starling.display
         public function get clipRect():Rectangle { return mClipRect; }
         public function set clipRect(value:Rectangle):void 
         {
-            if (mClipRect) mClipRect.setTo(value.x, value.y, value.width, value.height);
-            else mClipRect = value.clone();
+            if (mClipRect && value) mClipRect.copyFrom(value);
+            else mClipRect = (value ? value.clone() : null);
         }
 
         /** Returns the bounds of the container's clipRect in the given coordinate space, or


### PR DESCRIPTION
Hey Daniel -
The updated clipRect code breaks when you clear the clipRect with Sprite.clipRect = null - this is just a patch to fix that.
