### PR TITLE
DisplayObjectContainer.stableSortChildren

### DIFF
--- a/starling/src/starling/display/DisplayObjectContainer.as
+++ b/starling/src/starling/display/DisplayObjectContainer.as
@@ -243,6 +243,34 @@ package starling.display
             mChildren = mChildren.sort(compareFunction);
         }
         
+        /** Sorts the children using a stable sort algorithm, which means that ordering is
+         *  preserved for objects that are "equal" according to the function. 
+         * 
+         *  This is slightly less performant than the sortChildren method, but it prevents the 
+         *  flickering that can occur when depth-sorting children with the same depth value. */
+        public function stableSortChildren(compareFunction:Function):void
+        {
+            // insertion sort implementation
+            var nn :int = mChildren.length;
+            for (var i :int = 1; i < nn; i++) 
+            {
+                var a :DisplayObject = mChildren[i];
+                var j :int = i - 1;
+                var b :DisplayObject = mChildren[j];
+                
+                if (compareFunction(a, b) >= 0) continue;
+                
+                mChildren[i] = b;
+                for (j--; j >= 0; j--) 
+                {
+                    b = mChildren[j];
+                    if (compareFunction(a, b) >= 0) break;
+                    mChildren[j + 1] = b;
+                }
+                mChildren[j + 1] = a;
+            }
+        }
+        
         /** Determines if a certain object is a child of the container (recursively). */
         public function contains(child:DisplayObject):Boolean
         {


### PR DESCRIPTION
Hey Daniel -

This pull request adds a "stableSortChildren" method to DisplayObjectContainer, which is useful to prevent flickering when depth-sorting children who have the same depth value (the AS3 Vector.sort algorithm is, unfortunately, not stable).

I used the insertion sort algorithm for the implementation (http://en.wikipedia.org/wiki/Insertion_sort). Insertion sort doesn't have the best _theoretical_ runtime performance, but in practice it works very well for display object depth sorting: after the first sort of a given DisplayObjectContainer, subsequent sorts will generally be close to O(n) (because most displayObjects won't be out of order after just a single frame). It also does the sort in-place, so there's no extra allocations happening.
