### PR TITLE
Fixed bug where vertexID was being used instead of zero

### DIFF
--- a/starling/src/starling/utils/VertexData.as
+++ b/starling/src/starling/utils/VertexData.as
@@ -293,7 +293,7 @@ package starling.utils
             
             if (transformationMatrix == null)
             {
-                for (i=vertexID; i<numVertices; ++i)
+                for (i=0; i<numVertices; ++i)
                 {
                     x = mRawData[offset];
                     y = mRawData[int(offset+1)];
@@ -307,7 +307,7 @@ package starling.utils
             }
             else
             {
-                for (i=vertexID; i<numVertices; ++i)
+                for (i=0; i<numVertices; ++i)
                 {
                     x = mRawData[offset];
                     y = mRawData[int(offset+1)];


### PR DESCRIPTION
getBounds() function would not work when specifying numVertices that is smaller or equal to vertexID. This was because vertexID was being used incorrectly in the for loops. Zero should have been used instead.
