### PR TITLE
DisplayObject seemingly randomly flips while setting transformationMatrix

### DIFF
--- a/starling/src/starling/display/DisplayObject.as
+++ b/starling/src/starling/display/DisplayObject.as
@@ -422,10 +422,12 @@ package starling.display
             mScaleX = Math.sqrt(matrix.a * matrix.a + matrix.b * matrix.b);
             mSkewY  = Math.acos(matrix.a / mScaleX);
             
+            var cnt:int = 0;
             if (!isEquivalent(matrix.b, mScaleX * Math.sin(mSkewY)))
             {
                 mScaleX *= -1;
                 mSkewY = Math.acos(matrix.a / mScaleX);
+                cnt++;
             }
             
             mScaleY = Math.sqrt(matrix.c * matrix.c + matrix.d * matrix.d);
@@ -435,12 +437,23 @@ package starling.display
             {
                 mScaleY *= -1;
                 mSkewX = Math.acos(matrix.d / mScaleY);
+                cnt++;
             }
             
             if (isEquivalent(mSkewX, mSkewY))
             {
                 mRotation = mSkewX;
                 mSkewX = mSkewY = 0;
+
+                // While visually equivalent, if both scaleX and scaleY were
+                // inverted while setting this matrix, this can cause weird
+                // behavior if someone stored external state, such as in a
+                // two-finger drag handler.
+                if (cnt==2) {
+                  mScaleX *= -1;
+                  mScaleY *= -1;
+                  mRotation += (mRotation < Math.PI) ? Math.PI : -Math.PI;
+                }
             }
             else
             {


### PR DESCRIPTION
Under certain circumstances (that only the Gods of Matrix Math understand) when setting transformationMatrix, the display object will flip (invert scale) in both in the X and Y directions.  This is not desirable when the user has stored off stateful variables and is trying to make comparisons over time, as is often the case with drag-and-rotate touch handlers.

I have such a drag-and-rotate handler, and the object being rotated erratically flips without my fix. With the fix, it behaves perfectly.

The alternative (which I suspect many people have implemented) is to detect this flip condition after setting the transformation matrix, but that's cumbersome at every assignment.
