### PR TITLE
EventDispatcher: optimized access of listener[i] in removeEventListener()

### DIFF
--- a/starling/src/starling/events/EventDispatcher.as
+++ b/starling/src/starling/events/EventDispatcher.as
@@ -71,7 +71,10 @@ package starling.events
                     var remainingListeners:Vector.<Function> = new <Function>[];
                     
                     for (var i:int=0; i<numListeners; ++i)
-                        if (listeners[i] != listener) remainingListeners.push(listeners[i]);
+                    {
+                        var otherListener:Function = listeners[i];
+                        if (otherListener != listener) remainingListeners.push(otherListener);
+                    }
                     
                     mEventListeners[type] = remainingListeners;
                 }


### PR DESCRIPTION
Saved listener[i] into a variable so that you don't need to access it twice while looping.
