### PR TITLE
DisplayObjectContainer: return from setChildIndex() if index is the same

### DIFF
--- a/starling/src/starling/display/DisplayObjectContainer.as
+++ b/starling/src/starling/display/DisplayObjectContainer.as
@@ -214,6 +214,7 @@ package starling.display
         public function setChildIndex(child:DisplayObject, index:int):void
         {
             var oldIndex:int = getChildIndex(child);
+            if (oldIndex == index) return;
             if (oldIndex == -1) throw new ArgumentError("Not a child of this container");
             mChildren.splice(oldIndex, 1);
             mChildren.splice(index, 0, child);


### PR DESCRIPTION
Avoids two calls to splice(). Since splice() creates two arrays (the rest argument and the return), this should help avoid some garbage collection.
