### PR TITLE
Starling keyboard events can be cancelled, which then cancels native keyboard events

### DIFF
--- a/starling/src/starling/core/Starling.as
+++ b/starling/src/starling/core/Starling.as
@@ -566,9 +566,14 @@ package starling.core
             if (!mStarted) return;
             
             makeCurrent();
-            mStage.broadcastEvent(new starling.events.KeyboardEvent(
+            var keyEvent:starling.events.KeyboardEvent = new starling.events.KeyboardEvent(
                 event.type, event.charCode, event.keyCode, event.keyLocation, 
-                event.ctrlKey, event.altKey, event.shiftKey));
+                event.ctrlKey, event.altKey, event.shiftKey);
+            mStage.broadcastEvent(keyEvent);
+            if(keyEvent.isDefaultPrevented())
+            {
+            	event.preventDefault();
+            }
         }
         
         private function onResize(event:Event):void

--- a/starling/src/starling/events/KeyboardEvent.as
+++ b/starling/src/starling/events/KeyboardEvent.as
@@ -35,6 +35,7 @@ package starling.events
         private var mAltKey:Boolean;
         private var mCtrlKey:Boolean;
         private var mShiftKey:Boolean;
+        private var mIsDefaultPrevented:Boolean = false;
         
         /** Creates a new KeyboardEvent. */
         public function KeyboardEvent(type:String, charCode:uint=0, keyCode:uint=0, 
@@ -70,5 +71,12 @@ package starling.events
         
         /** Indicates whether the Shift key modifier is active (true) or inactive (false). */
         public function get shiftKey():Boolean { return mShiftKey; }
+
+        public function isDefaultPrevented():Boolean { return mIsDefaultPrevented; }
+
+        public function preventDefault():void
+        {
+            mIsDefaultPrevented = true;
+        }
     }
 }


### PR DESCRIPTION
Native KeyboardEvents are cancellable with preventDefault(). This is essential for certain keyCodes like Keyboard.BACK where you need to call preventDefault() to keep Android from handling the back button and leaving your app.

Starling should expose this ability to cancel keyboard events. If, after broadcastEvent() returns, the new function isDefaultPrevented() returns true, preventDefault() can be called on the native event.
