### PR TITLE
Fix regression from ccfc734.

### DIFF
--- a/starling/src/starling/textures/RenderTexture.as
+++ b/starling/src/starling/textures/RenderTexture.as
@@ -79,7 +79,7 @@ package starling.textures
             
             var nativeWidth:int  = getNextPowerOfTwo(width  * scale);
             var nativeHeight:int = getNextPowerOfTwo(height * scale);
-            mActiveTexture = Texture.empty(width, height, PMA, true, false, scale);
+            mActiveTexture = Texture.empty(width, height, PMA, true, true, scale);
             mActiveTexture.root.onRestore = mActiveTexture.root.clear;
             
             super(mActiveTexture, new Rectangle(0, 0, width, height), true);
@@ -89,7 +89,7 @@ package starling.textures
             
             if (persistent)
             {
-                mBufferTexture = Texture.empty(width, height, PMA, true, false, scale);
+                mBufferTexture = Texture.empty(width, height, PMA, true, true, scale);
                 mBufferTexture.root.onRestore = mBufferTexture.root.clear;
                 mHelperImage = new Image(mBufferTexture);
                 mHelperImage.smoothing = TextureSmoothing.NONE; // solves some antialias-issues


### PR DESCRIPTION
The commit that added the optimize for render parameter to Texture.empty() put a new boolean next to
an existing boolean argument, and when that new parameter was added to RenderTexture's usage, it was
put in the wrong location, flipping the correct values for mipmapping and optmize for render.
