### PR TITLE
AssetManager doesn't support json array encoding.

### DIFF
--- a/starling/src/starling/utils/AssetManager.as
+++ b/starling/src/starling/utils/AssetManager.as
@@ -589,7 +589,7 @@ package starling.utils
                         bytes.clear();
                         addTexture(name, texture);
                     }
-                    else if (byteArrayStartsWith(bytes, "{"))
+                    else if (byteArrayStartsWith(bytes, "{") || byteArrayStartsWith(bytes, "["))
                     {
                         addObject(name, JSON.parse(bytes.readUTFBytes(bytes.length)));
                         bytes.clear();


### PR DESCRIPTION
AssetManger checks for the first character of a string for '{' to determin whether or not it is JSON encoded string, however a json encoded array begins with a '['.

Example:

["test1","test2"]

is valid JSON
