### PR TITLE
New VertexData using ByteArray append() offset incorrect.

### DIFF
--- a/starling/src/starling/utils/VertexData.as
+++ b/starling/src/starling/utils/VertexData.as
@@ -156,7 +156,7 @@ package starling.utils
         /** Appends the vertices from another VertexData object. */
         public function append(data:VertexData):void
         {
-            mRawData.position = mNumVertices;
+            mRawData.position = mNumVertices * BYTES_PER_VERTEX;;
             mRawData.writeBytes(data.mRawData);
             mNumVertices += data.mNumVertices;
         }


### PR DESCRIPTION
Hey Daniel, 

Was working on porting over the Particle Extension to use the new ByteArray based vertex data and came across this bug.  See attached, pretty straight forward.
