### PR TITLE
Fixed TouchProcessor was dispatching only updated touches (issue #387)

### DIFF
--- a/starling/src/starling/events/TouchProcessor.as
+++ b/starling/src/starling/events/TouchProcessor.as
@@ -155,7 +155,7 @@ package starling.events
             
             // the same touch event will be dispatched to all targets;
             // the 'dispatch' method will make sure each bubble target is visited only once.
-            var touchEvent:TouchEvent = new TouchEvent(TouchEvent.TOUCH, touches, shiftDown, ctrlDown);
+            var touchEvent:TouchEvent = new TouchEvent(TouchEvent.TOUCH, mCurrentTouches, shiftDown, ctrlDown);
             var touch:Touch;
             
             // hit test our updated touches


### PR DESCRIPTION
This is my fix for issue #387 (see issue for discussion).  This fixed touch problems in the large project I ported from 1.3 to 1.4, and I believe this problem is a typo introduced during TouchProcessor refactoring.

Sorry for the duplicate issue - the pull request created it automatically.
