### PR TITLE
Resetting of index and vertex data implemented

### DIFF
--- a/starling/src/starling/display/QuadBatch.as
+++ b/starling/src/starling/display/QuadBatch.as
@@ -112,8 +112,20 @@ package starling.display
         {
             Starling.current.stage3D.removeEventListener(Event.CONTEXT3D_CREATE, onContextCreated);
             
-            if (mVertexBuffer) mVertexBuffer.dispose();
-            if (mIndexBuffer)  mIndexBuffer.dispose();
+            // Reset vertex and index data
+            mVertexData.numVertices = 0;
+            mIndexData.length = 0;
+            
+            if (mVertexBuffer)
+            {
+                mVertexBuffer.dispose();
+                mVertexBuffer = null;
+            }
+            if (mIndexBuffer) 
+            {
+                mIndexBuffer.dispose();
+                mIndexBuffer = null;
+            }
             
             super.dispose();
         }
@@ -170,8 +182,16 @@ package starling.display
             var numIndices:int = mIndexData.length;
             var context:Context3D = Starling.context;
 
-            if (mVertexBuffer)    mVertexBuffer.dispose();
-            if (mIndexBuffer)     mIndexBuffer.dispose();
+            if (mVertexBuffer)
+            {
+                mVertexBuffer.dispose();
+                mVertexBuffer = null;
+            }
+            if (mIndexBuffer)
+            {
+                mIndexBuffer.dispose();
+                mIndexBuffer = null;
+            }
             if (numVertices == 0) return;
             if (context == null)  throw new MissingContextError();
             


### PR DESCRIPTION
In the dispose call the index and vertex data is now reset. When disposed before this would never decrease the index and vertex data so if a reference to the QuadBatch still existed (for example being reused in RenderSupport) then unnecessary data could hang around and cause a build up of memory.

Clearing this should not be too expensive performance wise as dispose is not called that often on QuadBatches in general.

Also I nulled out the index and vertex buffers as it was possible that dispose could be called on them when they were already disposed
