### PR TITLE
fixed Image.getBounds and Quad.getBounds for non-zero upper left vertex case.

### DIFF
--- a/starling/src/starling/display/Image.as
+++ b/starling/src/starling/display/Image.as
@@ -148,6 +148,19 @@ package starling.display
             
             mVertexDataCache.copyTransformedTo(targetData, targetVertexID, matrix, 0, 4);
         }
+
+        /** @inheritDoc */
+        public override function getBounds(targetSpace:DisplayObject, resultRect:Rectangle=null):Rectangle
+        {
+            if (mVertexDataCacheInvalid)
+            {
+                mVertexDataCacheInvalid = false;
+                mVertexData.copyTo(mVertexDataCache);
+                mTexture.adjustVertexData(mVertexDataCache, 0, 4);
+            }
+            
+            return getBoundsImpl(targetSpace, resultRect, mVertexDataCache);
+        }
         
         /** The texture that is displayed on the quad. */
         public function get texture():Texture { return mTexture; }


### PR DESCRIPTION
Texture's frame could be used to align images that is a rasterized
version of a flash symbol that have a custom pivot (in the center of an
image for example). In order to get correct bounds (and therefore
hitTest) one has to consider upper left vertex of an Image (Quad).
