### PR TITLE
FragmentFilter changes and new Bloom Filter

### DIFF
--- a/starling/src/starling/filters/BloomFilter.as
+++ b/starling/src/starling/filters/BloomFilter.as
@@ -1,0 +1,112 @@
+// =================================================================================================
+//
+//	Starling Framework
+//	Copyright 2012 Gamua OG. All Rights Reserved.
+//
+//	This program is free software. You can redistribute and/or modify it
+//	in accordance with the terms of the accompanying license agreement.
+//
+// =================================================================================================
+
+package starling.filters
+{
+	import flash.display3D.Context3D;
+	import flash.display3D.Context3DBlendFactor;
+	import flash.display3D.Context3DProgramType;
+	import flash.display3D.Program3D;
+	import flash.display3D.VertexBuffer3D;
+	import flash.display3D.IndexBuffer3D;
+	import flash.geom.Rectangle;
+	import starling.filters.BlurFilter;
+	import starling.filters.FragmentFilter;
+	import starling.textures.Texture;
+	import starling.utils.getNextPowerOfTwo;
+	import starling.display.DisplayObject;
+	import starling.core.RenderSupport;
+	import starling.core.Starling;
+	import starling.display.BlendMode;
+	import starling.display.QuadBatch;
+	import starling.utils.VertexData;
+
+
+	/**
+	 * BloomFilter - provides a fog/bloom style effect
+	 *
+	 * In essence this filter takes the object you apply it to and:
+	 *   1. Copies it to a new layer
+	 *   2. Applies a guassian blur to it
+	 *   3. 'Blends' that layer with the original using the "lighten" blendmode
+	 */
+	public class BloomFilter extends FragmentFilter
+	{
+		protected var _lighten:Program3D = null; // lighten AGAL program
+		protected var _blur:BlurFilter = null; // blur filter to apply to the new layer
+
+		protected var _blurTex:Texture = null; // new layer
+		protected var _renderSupport:RenderSupport = null; // rendersupport to use new layer
+
+
+		public function BloomFilter(size:Number = 12)
+		{
+			super();
+			_blur = new BlurFilter(size, size);
+		}
+
+		public override function dispose():void
+		{
+			_lighten.dispose();
+			_blur.dispose();
+
+			_blurTex.dispose();
+			_renderSupport.dispose();
+			super.dispose();
+		}
+
+		protected override function createPrograms():void
+		{
+			var fragmentProgramCode:String =
+			"tex ft0, v0,  fs0 <2d, repeat, linear, mipnone>  \n" +
+			"tex ft1, v0,  fs1 <2d, repeat, linear, mipnone>  \n" +
+			"max ft2, ft1, ft0 \n" +
+			"mov oc, ft2 \n";
+		
+			_lighten = assembleAgal(fragmentProgramCode);
+		}
+
+		protected override function activate(pass:int, context:Context3D, texture:Texture):void
+		{
+			context.setTextureAt(1, _blurTex.base);
+			context.setProgram(_lighten)
+		}
+
+		protected override function deactivate(pass:int, context:Context3D, texture:Texture):void
+		{
+			context.setTextureAt(1, null);
+		}
+
+		public override function render(object:DisplayObject, support:RenderSupport, parentAlpha:Number):void
+		{
+
+			if (_blurTex == null) {
+				var sBounds:Rectangle = new Rectangle();
+				var sBoundsPot:Rectangle = new Rectangle();
+				var scale:Number = Starling.current.contentScaleFactor;
+				calculateBounds(object, object.stage, resolution * scale, false, sBounds, sBoundsPot);
+				// setup the texture (new layer) and the rendersupport to use it
+				_blurTex = Texture.empty(
+					sBoundsPot.width, 
+					sBoundsPot.height, 
+					PMA, 
+					false, 
+					true, 
+					resolution * scale
+				);
+				_renderSupport = new RenderSupport();
+				_renderSupport.renderTarget = _blurTex;
+
+			}
+			_blur.render(object, _renderSupport, parentAlpha);
+			super.render(object, support, parentAlpha);
+		}
+	}
+}

--- a/starling/src/starling/filters/FragmentFilter.as
+++ b/starling/src/starling/filters/FragmentFilter.as
@@ -227,12 +227,7 @@ package starling.filters
             // save original projection matrix and render target
             mProjMatrix.copyFrom(support.projectionMatrix); 
             var previousRenderTarget:Texture = support.renderTarget;
-            
-            if (previousRenderTarget)
-                throw new IllegalOperationError(
-                    "It's currently not possible to stack filters! " +
-                    "This limitation will be removed in a future Stage3D version.");
-            
+
             if (intoCache) 
                 cacheTexture = Texture.empty(sBoundsPot.width, sBoundsPot.height, PMA, false, true, 
                                              mResolution * scale);
@@ -266,17 +261,17 @@ package starling.filters
                 }
                 else // final pass
                 {
-                    if (intoCache)
+                    if (intoCache || previousRenderTarget)
                     {
                         // draw into cache texture
-                        support.renderTarget = cacheTexture;
+                        support.renderTarget = cacheTexture ? cacheTexture: previousRenderTarget;
                         support.clear();
                     }
                     else
                     {
                         // draw into back buffer, at original (stage) coordinates
                         support.projectionMatrix = mProjMatrix;
-                        support.renderTarget = previousRenderTarget;
+                        support.renderTarget = null;
                         support.translateMatrix(mOffsetX, mOffsetY);
                         support.blendMode = object.blendMode;
                         support.applyBlendMode(PMA);
@@ -378,10 +373,10 @@ package starling.filters
          *  rectangles: one with the exact filter bounds, the other with an extended rectangle that
          *  will yield to a POT size when multiplied with the current scale factor / resolution.
          */
-        private function calculateBounds(object:DisplayObject, stage:Stage, scale:Number, 
-                                         intersectWithStage:Boolean, 
-                                         resultRect:Rectangle,
-                                         resultPotRect:Rectangle):void
+        protected function calculateBounds(object:DisplayObject, stage:Stage, scale:Number, 
+                                           intersectWithStage:Boolean, 
+                                           resultRect:Rectangle,
+                                           resultPotRect:Rectangle):void
         {
             var marginX:Number, marginY:Number;
             


### PR DESCRIPTION
I've created a BloomFilter (like the fog filter in Pixelmator); basically a gaussian blur on a new layer, blended with the lighten mode.

To allow this I've had to make some changes to the FragmentFilter.  One (changing the protection on calculateBounds) is optional but useful if you ever need to do size calculations in a FragmentFilter subclass.

The other is to allow rendering to a filter, rather than the backbuffer; see here for an alternative solution http://forum.starling-framework.org/topic/mist-or-glow-filter

Overall I think this is a better solution as its more de-coupled.  In addition don't thing the (removed) assertion is valid -  Stage3D is quite happy to render AGAL programs to textures.

I think this also resolves #391 (its a bloom filter :); although I'd echo the comments there on making it easier to extend FragmentFilter as, although it's not a major issue given this implementation, it was a pain in the ass while trying other solutions.