### PR TITLE
added BlendMode UNDER to draw below objects

### DIFF
--- a/starling/src/starling/display/BlendMode.as
+++ b/starling/src/starling/display/BlendMode.as
@@ -44,7 +44,8 @@ package starling.display
                 "add"      : [ Context3DBlendFactor.SOURCE_ALPHA, Context3DBlendFactor.DESTINATION_ALPHA ],
                 "multiply" : [ Context3DBlendFactor.DESTINATION_COLOR, Context3DBlendFactor.ONE_MINUS_SOURCE_ALPHA ],
                 "screen"   : [ Context3DBlendFactor.SOURCE_ALPHA, Context3DBlendFactor.ONE ],
-                "erase"    : [ Context3DBlendFactor.ZERO, Context3DBlendFactor.ONE_MINUS_SOURCE_ALPHA ]
+                "erase"    : [ Context3DBlendFactor.ZERO, Context3DBlendFactor.ONE_MINUS_SOURCE_ALPHA ],
+                "under"    : [ Context3DBlendFactor.ONE_MINUS_DESTINATION_ALPHA, Context3DBlendFactor.DESTINATION_ALPHA ]
             },
             // premultiplied alpha
             { 
@@ -53,7 +54,8 @@ package starling.display
                 "add"      : [ Context3DBlendFactor.ONE, Context3DBlendFactor.ONE ],
                 "multiply" : [ Context3DBlendFactor.DESTINATION_COLOR, Context3DBlendFactor.ONE_MINUS_SOURCE_ALPHA ],
                 "screen"   : [ Context3DBlendFactor.ONE, Context3DBlendFactor.ONE_MINUS_SOURCE_COLOR ],
-                "erase"    : [ Context3DBlendFactor.ZERO, Context3DBlendFactor.ONE_MINUS_SOURCE_ALPHA ]
+                "erase"    : [ Context3DBlendFactor.ZERO, Context3DBlendFactor.ONE_MINUS_SOURCE_ALPHA ],
+                "under"    : [ Context3DBlendFactor.ONE_MINUS_DESTINATION_ALPHA, Context3DBlendFactor.DESTINATION_ALPHA ]
             }
         ];
         
@@ -84,6 +86,9 @@ package starling.display
         /** Erases the background when drawn on a RenderTexture. */
         public static const ERASE:String = "erase";
         
+		/** Draws under/below the existing objects. */
+	    public static const UNDER:String = "under";
+	
         // accessing modes
         
         /** Returns the blend factors that correspond with a certain mode and premultiplied alpha


### PR DESCRIPTION
Allow to draw on empty surface only, preserving the existing drawn objects. Can be use for easily color around shapes on flat textures for example.
