### PR TITLE
Add event when a url loader has completed

### DIFF
--- a/starling/src/starling/utils/AssetManager.as
+++ b/starling/src/starling/utils/AssetManager.as
@@ -34,6 +34,9 @@ package starling.utils
     /** Dispatched when all textures have been restored after a context loss. */
     [Event(name="texturesRestored", type="starling.events.Event")]
     
+    /** Dispatched when an url loader has finished loading.*/
+    [Event(name="urlLoaded", type="starling.events.Event")]
+    
     /** The AssetManager handles loading and accessing a variety of asset types. You can 
      *  add assets directly (via the 'add...' methods) or asynchronously via a queue. This allows
      *  you to deal with assets in a unified way, no matter if they are loaded from a file, 
@@ -793,6 +796,9 @@ package starling.utils
             
             function onUrlLoaderComplete(event:Object):void
             {
+                // Trigger an URL_LOADED event when an url loader has finished loading
+                dispatchEventWith('urlLoaded', urlLoader);
+            
                 var bytes:ByteArray = urlLoader.data as ByteArray;
                 var sound:Sound;
                 


### PR DESCRIPTION
Hi,

I'm looking into adding some sort of caching to AssetsManager.
My plan is to copy the loader's data to a local cache folder after loading an external resource then use that local url instead of the external url on subsequents loading.

However, at the moment I'm not sure where to hook my code to do the "put in cache" thing and even after looking carefully at the code, it seems impossible without beeing "invasive" :-)

I propose to add this simple event to let me hook my own "save to cache" code easily.
Using the urlLoader as event data, I can retrieve the url and the byte array and do my stuff.

Thanks for considering it (or pointing me to the right direction if you see a better way to do it).

Btw, I written the code "blind" (directly on github) so it may not be perfect.
