### PR TITLE
Added static Starling.all property to get all Starling instances

### DIFF
--- a/starling/src/starling/core/Starling.as
+++ b/starling/src/starling/core/Starling.as
@@ -213,6 +213,7 @@ package starling.core
         private static var sCurrent:Starling;
         private static var sHandleLostContext:Boolean;
         private static var sContextData:Dictionary = new Dictionary(true);
+		private static var sAll:Vector.<Starling> = new <Starling>[];
         
         // construction
         
@@ -274,6 +275,8 @@ package starling.core
             // for context data, we actually reference by stage3D, since it survives a context loss
             sContextData[stage3D] = new Dictionary();
             sContextData[stage3D][PROGRAM_DATA_NAME] = new Dictionary();
+
+			sAll.push(this);
             
             // all other modes are problematic in Starling, so we force those here
             stage.scaleMode = StageScaleMode.NO_SCALE;
@@ -344,6 +347,12 @@ package starling.core
                 if (disposeContext3D.length == 1) disposeContext3D(false);
                 else disposeContext3D();
             }
+
+			var index:int = sAll.indexOf(this);
+			if(index != -1)
+			{
+				sAll.splice(index, 1);
+			}
         }
         
         // functions
@@ -1058,5 +1067,11 @@ package starling.core
             else
                 sHandleLostContext = value;
         }
+
+		/** All Starling instances. <p>CAUTION: not a copy, but the actual object! Do not modify!</p> */
+		public static function get all():Vector.<Starling>
+		{
+			return sAll;
+		}
     }
 }


### PR DESCRIPTION
Similar to `Starling.current`, but it gets all Starling instances. An instance is added in its constructor and removed when its `dispose()` function is called.
## Use Cases

1) I have a reference to a `starling.display.Stage`. It would be nice if I could somehow get the `starling.core.Starling` instance that owns it. For instance, I might want to know the `nativeStage` that is associated with this Starling stage so that I can position something properly above Starling in an AIR `NativeWindow`. Looping through the vector returned by the static `Starling.all` property would allow me to find the right Starling instance pretty easily.

2) An AIR `NativeWindow` has a `stage` property, which makes it easy to access the native display list of the active window with `NativeApplication.activeWindow.stage`. However, there's no way to get a Starling stage for an arbitrary `NativeWindow`. Similar to the previous use case, I can loop through the static `Starling.all` property and check if `NativeApplication.activeWindow.stage` matches a Starling instance's `nativeStage` property.
