### PR TITLE
juggler.removeDelayedCall

### DIFF
--- a/starling/src/starling/animation/DelayedCall.as
+++ b/starling/src/starling/animation/DelayedCall.as
@@ -97,6 +97,9 @@ package starling.animation
         public function get repeatCount():int { return mRepeatCount; }
         public function set repeatCount(value:int):void { mRepeatCount = value; }
         
+		/** the actual function call **/
+		public function get call():Function { return mCall; };
+		
         // delayed call pooling
         
         private static var sPool:Vector.<DelayedCall> = new <DelayedCall>[];

--- a/starling/src/starling/animation/Juggler.as
+++ b/starling/src/starling/animation/Juggler.as
@@ -102,6 +102,23 @@ package starling.animation
             }
         }
         
+		/** Removes all delayedCalls for a certain call. */
+		public function removeDelayedCall( call:Function ):void
+		{
+			if( call == null ) return;
+			
+			for( var i:int=mObjects.length-1; i>=0; --i )
+			{
+				var delayed:DelayedCall = mObjects[i] as DelayedCall;
+				if (delayed && delayed.call == call)
+				{
+					delayed.removeEventListener(Event.REMOVE_FROM_JUGGLER, onRemove);
+					DelayedCall.starling_internal::toPool(delayed);
+					mObjects[i] = null;
+				}
+			}
+		}
+		
         /** Figures out if the juggler contains one or more tweens with a certain target. */
         public function containsTweens(target:Object):Boolean
         {

--- a/starling/src/starling/animation/Juggler.as
+++ b/starling/src/starling/animation/Juggler.as
@@ -113,7 +113,6 @@ package starling.animation
 				if (delayed && delayed.call == call)
 				{
 					delayed.removeEventListener(Event.REMOVE_FROM_JUGGLER, onRemove);
-					DelayedCall.starling_internal::toPool(delayed);
 					mObjects[i] = null;
 				}
 			}


### PR DESCRIPTION
added `juggler.removeDelayedCall(call)` to be able to remove a previously added `DelayedCall` with `juggler.delayedCall()` method or a manually added `DelayedCall` to the juggler. 
I just cloned the `juggler.removeTweens()` function and added a getter to the actual call in the `DelayedCall`