### PR TITLE
get characters in bitmap font

### DIFF
--- a/starling/src/starling/text/BitmapFont.as
+++ b/starling/src/starling/text/BitmapFont.as
@@ -153,6 +153,18 @@ package starling.text
             }
         }
         
+        /** Returns chars available in this bitmap font. */
+        public function getChars():Vector.<int>
+        {
+            var keys:Vector.<int> = new <int>[];
+            
+            for(var key:int in mChars){
+                keys[keys.length] = key;
+            }
+            
+            return keys;
+        }
+        
         /** Returns a single bitmap char with a certain character ID. */
         public function getChar(charID:int):BitmapChar
         {


### PR DESCRIPTION
I need to know which character ids are registered in bitmap font. Writing a simple get method seems easier than manually parsing the XML passed into BitmapFont constructor.
