### PR TITLE
Fixed > AssetManager: Texture removed from mTextures when adding a font...

### DIFF
--- a/starling/src/starling/utils/AssetManager.as
+++ b/starling/src/starling/utils/AssetManager.as
@@ -597,6 +597,7 @@ package starling.utils
                         if (texture)
                         {
                             addTextureAtlas(name, new TextureAtlas(texture, xml));
+							removeTexture(name, false);
 
                             if (mKeepAtlasXmls) addXml(name, xml);
                             else System.disposeXML(xml);
@@ -612,6 +613,7 @@ package starling.utils
                         {
                             log("Adding bitmap font '" + name + "'");
                             TextField.registerBitmapFont(new BitmapFont(texture, xml), name);
+							removeTexture(name, false);
 
                             if (mKeepFontXmls) addXml(name, xml);
                             else System.disposeXML(xml);


### PR DESCRIPTION
Fixed > AssetManager: Texture removed from mTextures when adding a font or atlas

(Problem explained on the forum: http://forum.starling-framework.org/topic/assetmanager-texture-atlas-issue-since-15#post-64980)