### PR TITLE
several BitmapData memory leaks

### DIFF
--- a/starling/src/starling/events/TouchMarker.as
+++ b/starling/src/starling/events/TouchMarker.as
@@ -88,8 +88,12 @@ package starling.events
             
             var bmpData:BitmapData = new BitmapData(width, height, true, 0x0);
             bmpData.draw(shape);
-            
-            return Texture.fromBitmapData(bmpData, false, false, scale);
+
+            const texture:Texture = Texture.fromBitmapData(bmpData, false, false, scale);
+
+            bmpData.dispose();
+
+            return texture;
         }
         
         private function get realMarker():Image { return getChildAt(0) as Image; }

--- a/starling/src/starling/text/MiniBitmapFont.as
+++ b/starling/src/starling/text/MiniBitmapFont.as
@@ -285,7 +285,12 @@ package starling.text
             bmpBytes.uncompress();
             bmpData.setPixels(new Rectangle(0, 0, BITMAP_WIDTH, BITMAP_HEIGHT), bmpBytes);
             
-            return Texture.fromBitmapData(bmpData, false);
+            const texture:Texture = Texture.fromBitmapData(bmpData, false);
+
+            bmpBytes.clear();
+            bmpData.dispose();
+
+            return texture;
         }
         
         public static function get xml():XML { return XML_DATA; }

--- a/starling/src/starling/text/TextField.as
+++ b/starling/src/starling/text/TextField.as
@@ -195,8 +195,11 @@ package starling.text
             {
                 if (mTextBounds == null)
                     mTextBounds = new Rectangle();
-                
-                texture.root.uploadBitmapData(renderText(scale, mTextBounds));
+
+                bitmapData = renderText(scale, mTextBounds);
+                texture.root.uploadBitmapData(bitmapData);
+
+                bitmapData.dispose();
             };
             
             bitmapData.dispose();


### PR DESCRIPTION
I noticed several BitmapData memory leaks in TouchMarker and MiniBitmapFont while profiling my app in Scout. So I investigated a bit more and noticed another non-disposed BitmapData object in TextField, although this one is not confirmed by Scout profiling. Thought I would share these quickfixes.
