### PR TITLE
suggestion : a PARSE_ERROR event for the asset manager.

### DIFF
--- a/starling/src/starling/events/Event.as
+++ b/starling/src/starling/events/Event.as
@@ -65,6 +65,8 @@ package starling.events
         public static const TEXTURES_RESTORED:String = "texturesRestored";
         /** Event type that is dispatched by the AssetManager when a file/url cannot be loaded. */
         public static const IO_ERROR:String = "ioError";
+		/** Event type that is dispatched by the AssetManager when a xml or json file couldn't be parsed */
+        public static const PARSE_ERROR:String = "parseError";
 
         /** An event type to be utilized in custom events. Not used by Starling right now. */
         public static const CHANGE:String = "change";

--- a/starling/src/starling/utils/AssetManager.as
+++ b/starling/src/starling/utils/AssetManager.as
@@ -37,7 +37,11 @@ package starling.utils
     
     /** Dispatched when an URLLoader fails with an IO_ERROR while processing the queue.
      *  The 'data' property of the Event contains the URL-String that could not be loaded. */
-    [Event(name="ioError", type="starling.events.Event")]
+    [Event(name = "ioError", type = "starling.events.Event")]
+	
+	/** Dispatched when an XML or JSON file couldn't be parsed.
+	 * The 'data' property of the Event contains the name of the asset that could not be parsed. */
+	[Event(name="parseError", type="starling.events.Event")]
 
     /** The AssetManager handles loading and accessing a variety of asset types. You can 
      *  add assets directly (via the 'add...' methods) or asynchronously via a queue. This allows
@@ -775,7 +779,9 @@ package starling.utils
                     else if (byteArrayStartsWith(bytes, "{") || byteArrayStartsWith(bytes, "["))
                     {
                         try { object = JSON.parse(bytes.readUTFBytes(bytes.length)); }
-                        catch (e:Error) { log("Could not parse JSON: " + e.message); }
+                        catch (e:Error) { log("Could not parse JSON: " + e.message); 
+							dispatchEventWith(Event.PARSE_ERROR, false, name);
+						}
 
                         if (object) addObject(name, object);
 
@@ -785,8 +791,10 @@ package starling.utils
                     else if (byteArrayStartsWith(bytes, "<"))
                     {
                         try { xml = new XML(bytes); }
-                        catch (e:Error) { log("Could not parse XML: " + e.message); }
-
+                        catch (e:Error) { log("Could not parse XML: " + e.message); 
+							dispatchEventWith(Event.PARSE_ERROR, false, name);
+						}
+						
                         process(xml);
                         bytes.clear();
                     }


### PR DESCRIPTION
This helps clearly determining that the cause for getObject(someDataAsset) returning null is not from an IO_ERROR or the asset not existing in the first place.

 If this data was requested by the app to the user or an external source, we can implement a backup plan by listening for this event such as switching to a default set of data or reloading it from another source, or at least give the user or the external source the proper feedback.

(edit: sorry for the bad indentation I have no idea how that got through because it doesn't show up like this in my editor. i just wanted to go ahead with a pull request just to save you a bit of time)
