### PR TITLE
Added TravisCI build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+git: 
+    depth: 1
+
+language: objective-c
+
+before_script:
+    - brew update
+    - brew install ant
+    - brew install adobe-air-sdk
+    - mkdir -p /usr/local/opt/adobe-air-sdk/libexec/frameworks/libs/player/11.1/
+    - cp -f /usr/local/opt/adobe-air-sdk/libexec/frameworks/libs/player/14.0/playerglobal.swc /usr/local/opt/adobe-air-sdk/libexec/frameworks/libs/player/11.1/
+    - "export AIR_HOME=/usr/local/opt/adobe-air-sdk/libexec"
+
+script:
+    - cd starling/build/ant && ant -DFLEX_HOME=/usr/local/opt/adobe-air-sdk/libexec


### PR DESCRIPTION
Continuous builds using Travis-CI service:
https://travis-ci.org/vpmedia/Starling-Framework/builds/31642080

I think this would be useful to validate other feature requests too, using automated scripts.

Please note that the ant build script assembles the SWC but does fail to run the ASDoc script, because OSX brew package manager has only AdobeAIR SDK support (Apache Flex SDK is problematic to install headless) so the Ant build script needs some refactoring.
Not sure that that should be done in a separated feature branch or in this one.

Cheers!
