### PR TITLE
add security error handler

### DIFF
--- a/starling/src/starling/events/Event.as
+++ b/starling/src/starling/events/Event.as
@@ -65,6 +65,8 @@ package starling.events
         public static const TEXTURES_RESTORED:String = "texturesRestored";
         /** Event type that is dispatched by the AssetManager when a file/url cannot be loaded. */
         public static const IO_ERROR:String = "ioError";
+        /** Event type that is dispatched by the AssetManager when a file/url cannot be loaded. */
+        public static const SECURITY_ERROR:String = "securityError";
         /** Event type that is dispatched by the AssetManager when an xml or json file couldn't be parsed */
         public static const PARSE_ERROR:String = "parseError";
 

--- a/starling/src/starling/utils/AssetManager.as
+++ b/starling/src/starling/utils/AssetManager.as
@@ -6,6 +6,7 @@ package starling.utils
     import flash.events.HTTPStatusEvent;
     import flash.events.IOErrorEvent;
     import flash.events.ProgressEvent;
+    import flash.events.SecurityErrorEvent;
     import flash.media.Sound;
     import flash.media.SoundChannel;
     import flash.media.SoundTransform;
@@ -889,6 +890,7 @@ package starling.utils
                 urlLoader = new URLLoader();
                 urlLoader.dataFormat = URLLoaderDataFormat.BINARY;
                 urlLoader.addEventListener(IOErrorEvent.IO_ERROR, onIoError);
+                urlLoader.addEventListener(SecurityErrorEvent.SECURITY_ERROR, onSecurityError);
                 urlLoader.addEventListener(HTTP_RESPONSE_STATUS, onHttpResponseStatus);
                 urlLoader.addEventListener(ProgressEvent.PROGRESS, onLoadProgress);
                 urlLoader.addEventListener(Event.COMPLETE, onUrlLoaderComplete);
@@ -901,7 +903,14 @@ package starling.utils
                 dispatchEventWith(Event.IO_ERROR, false, url);
                 complete(null);
             }
-            
+
+            function onSecurityError(event:SecurityErrorEvent):void
+            {
+                log("security error: " + event.text);
+                dispatchEventWith(Event.SECURITY_ERROR, false, url);
+                complete(null);
+            }
+
             function onHttpResponseStatus(event:HTTPStatusEvent):void
             {
                 if (extension == null)
@@ -968,6 +977,7 @@ package starling.utils
                 if (urlLoader)
                 {
                     urlLoader.removeEventListener(IOErrorEvent.IO_ERROR, onIoError);
+                    urlLoader.removeEventListener(SecurityErrorEvent.SECURITY_ERROR, onSecurityError);
                     urlLoader.removeEventListener(HTTP_RESPONSE_STATUS, onHttpResponseStatus);
                     urlLoader.removeEventListener(ProgressEvent.PROGRESS, onLoadProgress);
                     urlLoader.removeEventListener(Event.COMPLETE, onUrlLoaderComplete);


### PR DESCRIPTION
It handles, for example, the following error:

```
Error #2044: Unhandled securityError:. text=Error #2048: Security sandbox violation: <ourUrl> cannot load data from https://fbstatic-a.akamaihd.net/rsrc.php/v2/yo/r/UlIqmHJn-SK.gif.
    at path.assets::AssetManager/loadRawAsset()[D:\...\code-shared\src\main\as3\com\path\assets\AssetManager.as:890]
    at path.assets::LoggingAssetManager/loadRawAsset()[D:\...\code-shared\src\main\as3\com\path\assets\LoggingAssetManager.as:86]
    at path.assets::AssetManager/processRawAsset()[D:\...\code-shared\src\main\as3\com\path\assets\AssetManager.as:710]
    at Function/path.assets:AssetManager/loadQueue/path.assets:loadQueueElement()[D:\...\code-shared\src\main\as3\com\path\assets\AssetManager.as:604]
    at Function/path.assets:AssetManager/loadQueue/path.assets:loadNextQueueElement()[D:\...\code-shared\src\main\as3\com\path\assets\AssetManager.as:582]
    at path.assets::AssetManager/loadQueue()[D:\...\code-shared\src\main\as3\com\path\assets\AssetManager.as:569]
```

which causes, that AssetManager never reaches 100%.
