### PR TITLE
add check for http response status code

### DIFF
--- a/starling/src/starling/utils/AssetManager.as
+++ b/starling/src/starling/utils/AssetManager.as
@@ -933,6 +933,7 @@ package starling.utils
                     log("http response status error: " + status);
                     dispatchEventWith(Event.IO_ERROR, false, url);
                     complete(null);
+                    return;
                 }
 				
                 var bytes:ByteArray = transformData(urlLoader.data as ByteArray, url);


### PR DESCRIPTION
Some old versions of Adobe AIR have a bug - https://bugbase.adobe.com/index.cfm?event=bug&id=3197184. Even if the asset can't be loaded (response contains 404 http status code), URLLoader dispatches Event.COMPLETE event (instead of IOErrorEvent.IO_ERROR).
