### PR TITLE
Fix "Texture size is zero" error

### DIFF
--- a/starling/src/starling/textures/Texture.as
+++ b/starling/src/starling/textures/Texture.as
@@ -345,8 +345,8 @@ package starling.textures
             
             if (context == null) throw new MissingContextError();
             
-            var origWidth:Number  = width  * scale;
-            var origHeight:Number = height * scale;
+            var origWidth:Number  = Math.ceil(width  * scale);
+            var origHeight:Number = Math.ceil(height * scale);
             var useRectTexture:Boolean = !mipMapping && !repeat &&
                 Starling.current.profile != "baselineConstrained" &&
                 "createRectangleTexture" in context && format.indexOf("compressed") == -1;


### PR DESCRIPTION
Error repeat requirements:
1. Use `Texture.empty(width, height)`. (`width > 0` and `width < 1`)
2. Starling.contentScaleFactor < 1
So, `var origWidth:int = width * Starling.contentScaleFactor`, `origWidth` will be `0`. And `flash.display3D::Context3D/createRectangleTexture` throw `ArgumentError: Error #3681: Texture size is zero.`
