### PR TITLE
Fix issue with highResolutionDisplay

### DIFF
--- a/starling/src/starling/display/Stage.as
+++ b/starling/src/starling/display/Stage.as
@@ -115,7 +115,7 @@ package starling.display
             var star:Starling = Starling.current;
             
             if (destination == null)
-                destination = new BitmapData(star.backBufferWidth, star.backBufferHeight, transparent);
+                destination = new BitmapData(star.backBufferWidth * star.contentScaleFactor, star.backBufferHeight * star.contentScaleFactor, transparent);
             
             support.renderTarget = null;
             support.setOrthographicProjection(0, 0, mWidth, mHeight);


### PR DESCRIPTION
Hi,

On my macbook pro retina, the drawToBitmapData function was a little bit broken.
It does not take into account the contentScaleFactor.
This change fix it on my laptop, but I'm not sure it does not introduce another bug as I have trouble understanding the subtleties of mContentScaleFactor versus mNativeStageContentScaleFactor in Starling.

Thanks,

Seb
