### PR TITLE
Added new 'standard' profile into 'auto' profile detection

### DIFF
--- a/starling/src/starling/core/Starling.as
+++ b/starling/src/starling/core/Starling.as
@@ -356,7 +356,7 @@ package starling.core
             var currentProfile:String;
             
             if (profile == "auto")
-                profiles = ["baselineExtended", "baseline", "baselineConstrained"];
+                profiles = ["standard", "baselineExtended", "baseline", "baselineConstrained"];
             else if (profile is String)
                 profiles = [profile as String];
             else if (profile is Array)


### PR DESCRIPTION
Hi,

I've added the missing 'standard' profile into the auto-detection array (first one, I hope it's in the correct place).

More info about the profile itself:

https://blogs.adobe.com/flashplayer/2014/09/stage3d-standard-profile.html

Best,
Andrew
