### PR TITLE
Fixed ASDoc validation error

### DIFF
--- a/starling/src/starling/core/Starling.as
+++ b/starling/src/starling/core/Starling.as
@@ -886,7 +886,7 @@ package starling.core
          *
          *  <p>The returned number is not always in pixel units: HiDPI-displays with an activated
          *  'supportHighResolutions' setting will return the size in points. For actual pixel
-         *  values, call 'backBufferWidth' instead. */
+         *  values, call 'backBufferWidth' instead.</p> */
         public function get viewPortWidth():Number
         {
             return mClippedViewPort.width;
@@ -897,7 +897,7 @@ package starling.core
          *
          *  <p>The returned number is not always in pixel units: HiDPI-displays with an activated
          *  'supportHighResolutions' setting will return the size in points. For actual pixel
-         *  values, call 'backBufferHeight' instead. */
+         *  values, call 'backBufferHeight' instead.</p> */
         public function get viewPortHeight():Number
         {
             return mClippedViewPort.height;


### PR DESCRIPTION
Small fix for the following asdoc validation error:

```
Text for description in starling.core:Starling/viewPortHeight/get is not valid.
org.xml.sax.SAXParseException; lineNumber: 10; columnNumber: 54; The element type "p" must be terminated by the matching end-tag "</p>".

Text for description in starling.core:Starling/viewPortWidth/get is not valid.
org.xml.sax.SAXParseException; lineNumber: 10; columnNumber: 53; The element type "p" must be terminated by the matching end-tag "</p>".
```
