### PR TITLE
Optimization: double vertex and index buffers usage during Stage.drawToBitmapData

### DIFF
--- a/starling/src/starling/core/Starling.as
+++ b/starling/src/starling/core/Starling.as
@@ -52,6 +52,8 @@ package starling.core
     import starling.utils.VAlign;
     import starling.utils.execute;
     
+    use namespace starling_internal;
+    
     /** Dispatched when a new render context is created. The 'data' property references the context. */
     [Event(name="context3DCreate", type="starling.events.Event")]
     
@@ -487,8 +489,26 @@ package starling.core
          *  it is presented. This can be avoided by enabling <code>shareContext</code>.*/ 
         public function render():void
         {
+            if (prerender())
+            {
+                if (!mShareContext)
+                    RenderSupport.clear(mStage.color, 1.0);
+                
+                mStage.render(mSupport, 1.0);
+                mSupport.finishQuadBatch();
+                
+                if (mStatsDisplay)
+                    mStatsDisplay.drawCount = mSupport.drawCount;
+                
+                if (!mShareContext)
+                    mContext.present();
+            }
+        }
+        
+        starling_internal function prerender():Boolean
+        {
             if (!contextValid)
-                return;
+                return false;
             
             makeCurrent();
             updateViewPort();
@@ -509,17 +529,7 @@ package starling.core
                 mClippedViewPort.height / scaleY,
                 mStage.stageWidth, mStage.stageHeight, mStage.cameraPosition);
             
-            if (!mShareContext)
-                RenderSupport.clear(mStage.color, 1.0);
-            
-            mStage.render(mSupport, 1.0);
-            mSupport.finishQuadBatch();
-            
-            if (mStatsDisplay)
-                mStatsDisplay.drawCount = mSupport.drawCount;
-            
-            if (!mShareContext)
-                mContext.present();
+            return true;
         }
         
         private function updateViewPort(forceUpdate:Boolean=false):void
@@ -1013,6 +1023,8 @@ package starling.core
                 removeEventListener(starling.events.Event.ROOT_CREATED, onRootCreated);
             }
         }
+        
+        starling_internal function get support():RenderSupport { return mSupport; }
         
         /** The Starling stage object, which is the root of the display tree that is rendered. */
         public function get stage():Stage { return mStage; }

--- a/starling/src/starling/display/Stage.as
+++ b/starling/src/starling/display/Stage.as
@@ -123,23 +123,25 @@ package starling.display
         public function drawToBitmapData(destination:BitmapData=null,
                                          transparent:Boolean=true):BitmapData
         {
-            var support:RenderSupport = new RenderSupport();
             var star:Starling = Starling.current;
+            var prendered:Boolean = star.prerender();
             
             if (destination == null)
                 destination = new BitmapData(star.backBufferWidth, star.backBufferHeight, transparent);
             
-            support.renderTarget = null;
-            support.setProjectionMatrix(0, 0, mWidth, mHeight, mWidth, mHeight, cameraPosition);
-            
-            if (transparent) support.clear();
-            else             support.clear(mColor, 1);
-            
-            render(support, 1.0);
-            support.finishQuadBatch();
-            
-            Starling.current.context.drawToBitmapData(destination);
-            Starling.current.context.present(); // required on some platforms to avoid flickering
+            if (prendered)
+            {
+                var support:RenderSupport = star.support;
+                
+                if (transparent) support.clear();
+                else             support.clear(mColor, 1);
+                
+                render(support, 1.0);
+                support.finishQuadBatch();
+                
+                star.context.drawToBitmapData(destination);
+                star.context.present(); // required on some platforms to avoid flickering
+            }
             
             return destination;
         }


### PR DESCRIPTION
In Facebook web games to show html (FB popups, for example) over flash with wmode direct we are doing stage screenshots, jpeg them, encode into base64 string and pass it to javascript, which in turn hides flash and replaces it with image received. I think, that’s usual approach for Starling Facebook games.
The problem is that some of our users are getting errors like that sometimes:
ArgumentError: Error #3672: Buffer creation failed. Internal error.
at flash.display3D::Context3D/createVertexBuffer()
at starling.display::QuadBatch/createBuffers()
at starling.display::QuadBatch/syncBuffers()
at starling.display::QuadBatch/renderCustom()
...
which are thrown from random QuadBatches. And for some reason before this change quite a lot of such errors were thrown from drawToBitmapData function. It means, that rendering into bitmap works much worse than usual render for some reason, taking into account, that it happens let’s say once per 10 minutes, and render happens every frame. Probably that’s because buffers are reused in usual rendering.
In this change I reused Starling’s render support object.
Documentation states: “Buffer Creation Failed: if the VertexBuffer3D object could not be created by the rendering context (but additional information about the reason is not available).” So it’s not completely clear for me, why this error happens, but after this change it’s very likely, that new vertex and index buffers won’t be created at all during stage drawing into bitmap. It means twice less GPU memory usage for vertex and index buffers and speed up of the function as there is no need to create them.
Also current implementation doesn’t dispose RenderSupport object created, which can cause GPU memory leaks. And it’s not needed after the change.
The change also includes context validity check, if context isn’t valid, function won’t crash, but will return empty bitmap.
Also it will try to reconfigure back buffer, if it’s needed.
The thing, I’m not sure about is using mClippedViewPort for setProjectionMatrix’s parameters instead of stage, this way it should render only visible stage part, if I’m not mistaken. It seems to me, that it’s more correct behaviour, but I’m not sure.