### PR TITLE
Bugfix: RenderTexture's draw and drawBundled methods threw exceptions if context was lost.

### DIFF
--- a/starling/src/starling/textures/RenderTexture.as
+++ b/starling/src/starling/textures/RenderTexture.as
@@ -189,6 +189,8 @@ package starling.textures
         
         private function render(object:DisplayObject, matrix:Matrix=null, alpha:Number=1.0):void
         {
+            if (!Starling.current.contextValid) return;
+
             var filter:FragmentFilter = object.filter;
 
             mSupport.loadIdentity();
@@ -208,6 +210,7 @@ package starling.textures
         {
             var context:Context3D = Starling.context;
             if (context == null) throw new MissingContextError();
+            if (!Starling.current.contextValid) return;
             
             // switch buffers
             if (isDoubleBuffered)
@@ -254,6 +257,7 @@ package starling.textures
         {
             var context:Context3D = Starling.context;
             if (context == null) throw new MissingContextError();
+            if (!Starling.current.contextValid) return;
             
             mSupport.renderTarget = mActiveTexture;
             mSupport.clear(rgb, alpha);


### PR DESCRIPTION
It's basically the same issue as was discussed here [627](https://github.com/Gamua/Starling-Framework/pull/627).
