### PR TITLE
empty TextField fix in 1.6 RC

### DIFF
--- a/starling/src/starling/text/TextField.as
+++ b/starling/src/starling/text/TextField.as
@@ -260,12 +260,13 @@ package starling.text
             sNativeTextField.antiAliasType = AntiAliasType.ADVANCED;
             sNativeTextField.selectable = false;            
             sNativeTextField.multiline = true;            
-            sNativeTextField.wordWrap = true;            
-            sNativeTextField.embedFonts = true;
-            sNativeTextField.filters = mNativeFilters;
+            sNativeTextField.wordWrap = true;         
 
             if (mIsHtmlText) sNativeTextField.htmlText = mText;
             else             sNativeTextField.text     = mText;
+               
+            sNativeTextField.embedFonts = true;
+            sNativeTextField.filters = mNativeFilters;
             
             // we try embedded fonts first, non-embedded fonts are just a fallback
             if (sNativeTextField.textWidth == 0.0 || sNativeTextField.textHeight == 0.0)


### PR DESCRIPTION
I have the same issue as people describe on this post http://forum.starling-framework.org/topic/starling-16-release-candidate
The order of setting embedFonts=true matters in native TextField
