### PR TITLE
Open mCall in DelayedCall

### DIFF
--- a/starling/src/starling/animation/DelayedCall.as
+++ b/starling/src/starling/animation/DelayedCall.as
@@ -86,6 +86,9 @@ package starling.animation
             return mRepeatCount == 1 && mCurrentTime >= mTotalTime; 
         }
         
+        /** The function, that will be called */
+        public function get call():Function { return mCall; }
+        
         /** The time for which calls will be delayed (in seconds). */
         public function get totalTime():Number { return mTotalTime; }
         


### PR DESCRIPTION
Sorry my english.

My class with call getter:

```as3
public class InstantDelayedCall implements IAnimatable
{
	public function InstantDelayedCall(call:Function, delay:Number)
	{
		_delayedCall = new DelayedCall(call, delay);
		_juggler.add(_delayedCall);
	}
	
	public function advanceTime(time:Number):void
	{
		if (_delayedCall.currentTime == 0) _delayedCall.call();
		_juggler.advanceTime(time);
	}
	
	private var _juggler:Juggler = new Juggler();
	private var _delayedCall:DelayedCall;
}
```

without call getter:

```as3
public class InstantDelayedCall implements IAnimatable
{
	public function InstantDelayedCall(call:Function, delay:Number)
	{
		_call = call;
		_delayedCall = new DelayedCall(call, delay);
		_juggler.add(_delayedCall);
	}
	
	public function advanceTime(time:Number):void
	{
		if (_delayedCall.currentTime == 0) _call();
		_juggler.advanceTime(time);
	}
	
	private var _call:Function;
	private var _juggler:Juggler = new Juggler();
	private var _delayedCall:DelayedCall;
}
```

I want to store "call" only in one place.
Maybe "DelayedCall.mArgs" should be opened too.

Sorry if i sound rude. I know english bad.