### PR TITLE
avoiding Texture size overflow when creating TextField with long long texts by lowering its resolution.

### DIFF
--- a/starling/src/starling/text/TextField.as
+++ b/starling/src/starling/text/TextField.as
@@ -90,6 +90,8 @@ package starling.text
     {
         // the name container with the registered bitmap fonts
         private static const BITMAP_FONT_DATA_NAME:String = "starling.display.TextField.BitmapFonts";
+        // The maximum size of texture to render
+        private static const MAX_TEXTURE_DIMENSION:Number = 2048;
         
         // the texture format that is used for TTF rendering
         private static var sDefaultTextureFormat:String =
@@ -195,6 +197,17 @@ package starling.text
             var scale:Number = Starling.contentScaleFactor;
             var bitmapData:BitmapData = renderText(scale, mTextBounds);
             var format:String = sDefaultTextureFormat;
+            
+            // re-render when size of rendered bitmap overflows MAX_TEXTURE_DIMENSION.
+            var shrinkHelper:Number = 0;
+            while (bitmapData.width > MAX_TEXTURE_DIMENSION || bitmapData.height > MAX_TEXTURE_DIMENSION) {
+                scale *= Math.min(
+                    (MAX_TEXTURE_DIMENSION - shrinkHelper) / Number(bitmapData.width),
+                    (MAX_TEXTURE_DIMENSION - shrinkHelper) / Number(bitmapData.height)
+                );
+                bitmapData = renderText(scale , mTextBounds);
+                shrinkHelper += 1;
+            }
             
             mHitArea.width  = bitmapData.width  / scale;
             mHitArea.height = bitmapData.height / scale;

--- a/tests/src/FlexUnitRunner.as
+++ b/tests/src/FlexUnitRunner.as
@@ -17,6 +17,7 @@ package
     import tests.display.Sprite3DTest;
     import tests.events.EventTest;
     import tests.geom.PolygonTest;
+    import tests.text.TextFieldTest;
     import tests.textures.TextureAtlasTest;
     import tests.textures.TextureTest;
     import tests.utils.AssetManagerTest;
@@ -55,6 +56,7 @@ package
             testsToRun.push(tests.animation.DelayedCallTest);
             testsToRun.push(tests.display.DisplayObjectTest);
             testsToRun.push(tests.utils.ColorTest);
+            testsToRun.push(tests.text.TextFieldTest);
             testsToRun.push(tests.textures.TextureTest);
             testsToRun.push(tests.textures.TextureAtlasTest);
             testsToRun.push(tests.events.EventTest);

--- a/tests/src/tests/text/TextFieldTest.as
+++ b/tests/src/tests/text/TextFieldTest.as
@@ -1,0 +1,71 @@
+package tests.text
+{
+	import flexunit.framework.Assert;
+	
+	import org.hamcrest.assertThat;
+	import org.hamcrest.number.greaterThan;
+	import org.hamcrest.number.lessThanOrEqualTo;
+	
+	import starling.display.Image;
+	import starling.text.TextField;
+	import starling.text.TextFieldAutoSize;
+	import starling.textures.Texture;
+	
+	import tests.StarlingTestCase;
+
+	public class TextFieldTest extends StarlingTestCase
+	{
+		private const MAX_TEXTURE_DIMENSION:Number = 2048;
+		private const SUPER_LARGE_TEXT_LENGTH:Number = 3200;
+		
+		[Test]
+		public function testTextField():void
+		{
+			var textField:TextField = new TextField(240, 50, "test text", "_sans", 16);
+			Assert.assertEquals("test text", textField.text);
+		}
+		
+		[Test]
+		public function testLargeTextField():void
+		{
+			var textField:TextField = new TextField(240, 50, sampleString(SUPER_LARGE_TEXT_LENGTH), "_sans", 32);
+			textField.autoSize = TextFieldAutoSize.VERTICAL;
+			
+			assertThat(textField.height, greaterThan(MAX_TEXTURE_DIMENSION));
+			
+			var textureSize:Texture = mainTextureFromTextField(textField);
+			Assert.assertTrue(textureSize);
+			assertThat(textureSize ? textureSize.height * textureSize.scale : 0, lessThanOrEqualTo(MAX_TEXTURE_DIMENSION));
+		}
+		
+		/**
+		 * Sample String longer than leastLength.
+		 * @param leastLength
+		 * @return 
+		 */
+		private function sampleString(leastLength:int):String {
+			const sample:String = "This is Sample String. ";
+			var repeat:int = Math.ceil(leastLength / sample.length);
+			var parts:Vector.<String> = new Vector.<String>(repeat);
+			for (var i:int = 0; i < repeat; i++) {
+				parts[i] = sample;
+			}
+			return parts.join();
+		}
+		
+		/**
+		 * returns Texture from main Image of TextFields.
+		 * @param textField.
+		 * @return main texture.
+		 */
+		private function mainTextureFromTextField(textField:TextField):Texture {
+			for (var i:int = 0; i < textField.numChildren; i++) {
+				var image:Image = textField.getChildAt(i) as Image;
+				if (image) {
+					return image.texture;
+				}
+			}
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
This is a feature that avoid texture size exceeds the system limit when you create TextFields contains very large font or long string.
If bitmap data from the native flash TextField has over 2048 pixels width or height, It 'll be re-rendered lowering the resolution to fit in 2048x2048.