### PR TITLE
Define Starling root after constructor

### DIFF
--- a/starling/src/starling/core/Starling.as
+++ b/starling/src/starling/core/Starling.as
@@ -250,7 +250,6 @@ package starling.core
                                  renderMode:String="auto", profile:Object="baselineConstrained")
         {
             if (stage == null) throw new ArgumentError("Stage must not be null");
-            if (rootClass == null) throw new ArgumentError("Root class must not be null");
             if (viewPort == null) viewPort = new Rectangle(0, 0, stage.stageWidth, stage.stageHeight);
             if (stage3D == null) stage3D = stage.stage3Ds[0];
 
@@ -448,12 +447,15 @@ package starling.core
         
         private function initializeRoot():void
         {
-            if (mRoot == null)
+            if (mRootClass != null && mRoot == null)
             {
-                mRoot = new mRootClass() as DisplayObject;
+                root = new mRootClass() as DisplayObject;
                 if (mRoot == null) throw new Error("Invalid root class: " + mRootClass);
-                mStage.addChildAt(mRoot, 0);
-            
+                dispatchEventWith(starling.events.Event.ROOT_CREATED, false, mRoot);
+            }
+            else if (mRoot != null && mRoot.parent == null)
+            {
+                mStage.addChildAt(root, 0);
                 dispatchEventWith(starling.events.Event.ROOT_CREATED, false, mRoot);
             }
         }
@@ -1020,6 +1022,12 @@ package starling.core
         /** The instance of the root class provided in the constructor. Available as soon as 
          *  the event 'ROOT_CREATED' has been dispatched. */
         public function get root():DisplayObject { return mRoot; }
+        public function set root(value:DisplayObject):void
+        {
+            if (mRoot != null) mRoot.removeFromParent(true);
+            mRoot = value;
+            if (mRoot != null && mContext != null) mStage.addChildAt(mRoot, 0);
+        }
         
         /** Indicates if the Context3D render calls are managed externally to Starling, 
          *  to allow other frameworks to share the Stage3D instance. @default false */


### PR DESCRIPTION
It would be helpful if we could fully initialize Starling before providing it with the root display object. Sometimes, I want to do something between Starling initializing and the root display object being created. Especially if I need multiple NativeWindows in AIR desktop.

There is precedence to creating a stage without a root in the native display list. In AIR, when you create a NativeWindow, it has a stage, but no root. If I were to wrap NativeWindow in a Feathers component, it would make sense to offer the same experience.

In my plans to support MXML in Feathers, I'd like to have a main application class that abstracts Starling initialization. It would be ideal if I could set up a Feathers theme before the root is created so that the root can be a Feathers component. It's technically possible now, but it requires manual work for developers that I would  rather abstract away.

In my implementation, I made the following changes:

1) The rootClass parameter in the constructor may be set to null. initializeRoot() checks for this new possibility.

2) I added a root setter that can accept a display object. If a root already exists, it will be removed and disposed. If Starling hasn't fully initialized, the new root will be saved until initializeRoot() is called. In initializeRoot(), the saved root will it be added to the stage, and Event.ROOT_CREATED will be dispatched. If the root setter is used after initializeRoot() has been called, the new root is immediately added to the stage without an event.

The normal case of passing a valid rootClass to the constructor should behave exactly the same.