### PR TITLE
Update travis.yml to AIR SDK 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # =================================================================================================
 #
 #	Starling Framework
-#	Copyright 2011-2014 Gamua. All Rights Reserved.
+#	Copyright 2011-2015 Gamua. All Rights Reserved.
 #
 #	This program is free software. You can redistribute and/or modify it
 #	in accordance with the terms of the accompanying license agreement.
@@ -36,14 +36,14 @@ before_script:
     - echo env.PLAYERGLOBAL_HOME=libs/player > flex_sdk/env.properties
     # Init Apache Flex SDK
     - mkdir -p flex_sdk/frameworks/libs/player/11.1/
-    - mkdir -p flex_sdk/frameworks/libs/player/16.0/
-    - cp -f /usr/local/opt/adobe-air-sdk/libexec/frameworks/libs/player/16.0/playerglobal.swc flex_sdk/frameworks/libs/player/11.1/
-    - cp -f /usr/local/opt/adobe-air-sdk/libexec/frameworks/libs/player/16.0/playerglobal.swc flex_sdk/frameworks/libs/player/16.0/
+    - mkdir -p flex_sdk/frameworks/libs/player/17.0/
+    - cp -f /usr/local/opt/adobe-air-sdk/libexec/frameworks/libs/player/17.0/playerglobal.swc flex_sdk/frameworks/libs/player/11.1/
+    - cp -f /usr/local/opt/adobe-air-sdk/libexec/frameworks/libs/player/17.0/playerglobal.swc flex_sdk/frameworks/libs/player/17.0/
     # Set env. variable used by Ant and Gradle
     - export FLEX_HOME="$TRAVIS_BUILD_DIR/flex_sdk"
     # Init Adobe AIR SDK
     - mkdir -p /usr/local/opt/adobe-air-sdk/libexec/frameworks/libs/player/11.1/
-    - cp -f /usr/local/opt/adobe-air-sdk/libexec/frameworks/libs/player/16.0/playerglobal.swc /usr/local/opt/adobe-air-sdk/libexec/frameworks/libs/player/11.1/
+    - cp -f /usr/local/opt/adobe-air-sdk/libexec/frameworks/libs/player/17.0/playerglobal.swc /usr/local/opt/adobe-air-sdk/libexec/frameworks/libs/player/11.1/
     # Set env. variable used by Ant and Gradle
     - export AIR_HOME="/usr/local/opt/adobe-air-sdk/libexec"
     # permissions


### PR DESCRIPTION
Hi,
I've updated the Travis YML file to use Adobe AIR SDK v17.
p.s.: The formulae now lives here: https://github.com/Homebrew/homebrew-binary/pull/197

Best Regards!