### PR TITLE
Fix documentation on max quads

### DIFF
--- a/starling/src/starling/display/QuadBatch.as
+++ b/starling/src/starling/display/QuadBatch.as
@@ -345,7 +345,7 @@ package starling.display
         /** Indicates if specific quads can be added to the batch without causing a state change. 
          *  A state change occurs if the quad uses a different base texture, has a different 
          *  'tinted', 'smoothing', 'repeat' or 'blendMode' setting, or if the batch is full
-         *  (one batch can contain up to 8192 quads). */
+         *  (one batch can contain up to 16383 quads). */
         public function isStateChange(tinted:Boolean, parentAlpha:Number, texture:Texture, 
                                       smoothing:String, blendMode:String, numQuads:int=1):Boolean
         {


### PR DESCRIPTION
I'm not sure if this should be 16383 or 16382 (16382 would be double the old value), but this updates the comment to match the constant.