### PR TITLE
Added check in contextValid() method for empty context.driverInfo String

### DIFF
--- a/starling/src/starling/core/Starling.as
+++ b/starling/src/starling/core/Starling.as
@@ -1102,7 +1102,14 @@ package starling.core
          *  internal code Starling can't avoid), so do not call this method too often. */
         public function get contextValid():Boolean
         {
-            return mContext && mContext.driverInfo != "Disposed";
+            if(mContext) {
+                const driverInfo:String = mContext.driverInfo;
+                if(driverInfo && driverInfo != "" && driverInfo != "Disposed") 
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         // static properties


### PR DESCRIPTION
Hi!

I've noticed in some exception log files that the Context3D.driverInfo string can be empty, and in this case the context is also invalid. (The Context3D.profile has null value both when the string is empty "''" or 'Disposed'). The problem occurs mostly using Flash Player 16.X.

Just for note: the documentation about the possible values is not really detailed: http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/display3D/Context3D.html#driverInfo

Best regards!
Andrew