### PR TITLE
Add "requiresRedraw" to starling.text.TextField

### DIFF
--- a/starling/src/starling/text/TextField.as
+++ b/starling/src/starling/text/TextField.as
@@ -253,6 +253,11 @@ package starling.text
          *  @param textFormat the default text format that's currently set on the text field.
          */
         protected function formatText(textField:flash.text.TextField, textFormat:TextFormat):void {}
+        
+        final protected function requiresRedraw():void 
+        {
+        	mRequiresRedraw = true;
+        }
 
         private function renderText(scale:Number, resultTextBounds:Rectangle):BitmapData
         {


### PR DESCRIPTION
Please add "requiresRedraw" to starling.text.TextField

I need it in my class:
```
public class WordWrapTextField extends starling.text.TextField
{
	private var mWordWrap:Boolean;
 
	override protected function formatText(textField:flash.text.TextField, textFormat:TextFormat):void
	{
		super.formatText(textField, textFormat);
		textField.wordWrap = mWordWrap;
	}
	 
	public function get wordWrap ():Boolean { return mWordWrap }
	public function set wordWrap (value:Boolean):void
	{
		mWordWrap = value;
		super.requiresRedraw();
	}
}
```
Thanks.