### PR TITLE
Fix issue with Textfield when native filters are applied

### DIFF
--- a/starling/src/starling/core/Starling.as
+++ b/starling/src/starling/core/Starling.as
@@ -587,7 +587,8 @@ package starling.core
                                              wantsBestResolution:Boolean=false):void
         {
             enableDepthAndStencil &&= SystemUtil.supportsDepthAndStencil;
-
+			width = (width < 32) ? 32 : width;
+			height = (height < 32) ? 32 : height;
             var configureBackBuffer:Function = mContext.configureBackBuffer;
             var methodArgs:Array = [width, height, antiAlias, enableDepthAndStencil];
             if (configureBackBuffer.length > 4) methodArgs.push(wantsBestResolution);

--- a/starling/src/starling/text/TextField.as
+++ b/starling/src/starling/text/TextField.as
@@ -305,15 +305,16 @@ package starling.text
                 sNativeTextField.embedFonts = false;
             
             formatText(sNativeTextField, textFormat);
+			
+			// if 'nativeFilters' are in use, the text field might grow beyond its bounds
+			var filterOffset:Rectangle = calculateFilterOffset(sNativeTextField);
             
             if (mAutoScale)
-                autoScaleNativeTextField(sNativeTextField);
+                autoScaleNativeTextField(sNativeTextField, filterOffset);
             
             var textWidth:Number  = sNativeTextField.textWidth;
             var textHeight:Number = sNativeTextField.textHeight;
 			
-			// if 'nativeFilters' are in use, the text field might grow beyond its bounds
-			var filterOffset:Rectangle = calculateFilterOffset(sNativeTextField);
             if (isHorizontalAutoSize)
                 sNativeTextField.width = width = Math.ceil(textWidth + filterOffset.width + FLASH_TEXT_OFFSET * 2);
             if (isVerticalAutoSize)
@@ -380,11 +381,11 @@ package starling.text
             return bitmapData;
         }
         
-        private function autoScaleNativeTextField(textField:flash.text.TextField):void
+       private function autoScaleNativeTextField(textField:flash.text.TextField, filterOffset:Rectangle):void
         {
-            var size:Number   = Number(textField.defaultTextFormat.size);
-            var maxHeight:int = textField.height - 4;
-            var maxWidth:int  = textField.width  - 4;
+            var size:Number = Number(textField.defaultTextFormat.size);
+            var maxWidth:int  = textField.width  - FLASH_TEXT_OFFSET * 2 - filterOffset.width;
+            var maxHeight:int = textField.height - FLASH_TEXT_OFFSET * 2 - filterOffset.height;
             
             while (textField.textWidth > maxWidth || textField.textHeight > maxHeight)
             {

--- a/starling/src/starling/text/TextField.as
+++ b/starling/src/starling/text/TextField.as
@@ -376,6 +376,8 @@ package starling.text
                 else             textField.text     = mText;
             }
         }
+		
+		static private const sBD:BitmapData = new BitmapData(1, 1, false);
         
         private function calculateFilterOffset(textField:flash.text.TextField,
                                                hAlign:String, vAlign:String):Point
@@ -388,33 +390,23 @@ package starling.text
                 var textWidth:Number  = textField.textWidth;
                 var textHeight:Number = textField.textHeight;
                 var bounds:Rectangle  = new Rectangle();
-                
-                for each (var filter:BitmapFilter in filters)
-                {
-                    var blurX:Number    = "blurX"    in filter ? filter["blurX"]    : 0;
-                    var blurY:Number    = "blurY"    in filter ? filter["blurY"]    : 0;
-                    var angleDeg:Number = "angle"    in filter ? filter["angle"]    : 0;
-                    var distance:Number = "distance" in filter ? filter["distance"] : 0;
-                    var angle:Number = deg2rad(angleDeg);
-                    var marginX:Number = blurX * 1.33; // that's an empirical value
-                    var marginY:Number = blurY * 1.33;
-                    var offsetX:Number  = Math.cos(angle) * distance - marginX / 2.0;
-                    var offsetY:Number  = Math.sin(angle) * distance - marginY / 2.0;
-                    var filterBounds:Rectangle = new Rectangle(
-                        offsetX, offsetY, textWidth + marginX, textHeight + marginY);
-                    
-                    bounds = bounds.union(filterBounds);
-                }
-                
-                if (hAlign == HAlign.LEFT && bounds.x < 0)
+				
+				for each (var filter:BitmapFilter in filters) {
+					var filterBounds:Rectangle = sBD.generateFilterRect( sBD.rect, filter );
+					bounds = bounds.union(filterBounds);
+				}
+				bounds.width -= 1;
+				bounds.height -= 1;
+				
+				if (hAlign == HAlign.LEFT && bounds.x < 0)
                     resultOffset.x = -bounds.x;
-                else if (hAlign == HAlign.RIGHT && bounds.y > 0)
-                    resultOffset.x = -(bounds.right - textWidth);
+                else if (hAlign == HAlign.RIGHT && bounds.right > 0)
+                    resultOffset.x = -bounds.right;
                 
                 if (vAlign == VAlign.TOP && bounds.y < 0)
                     resultOffset.y = -bounds.y;
-                else if (vAlign == VAlign.BOTTOM && bounds.y > 0)
-                    resultOffset.y = -(bounds.bottom - textHeight);
+                else if (vAlign == VAlign.BOTTOM && bounds.bottom > 0)
+                    resultOffset.y = -bounds.bottom;
             }
             
             return resultOffset;


### PR DESCRIPTION
```
// calculateFilterOffset bug
var tf:TextField = new TextField(100, 40, 'Playgame', "Verdana", 15);
tf.hAlign = HAlign.RIGHT;
tf.border = true;
tf.nativeFilters = [new DropShadowFilter(20, 0, 0xFF00F0, 1, 1, 1, 1)]
addChild(tf);
tf.x = 50;
tf.y = 20;

// autosize bug
var tf2:TextField = new TextField(100, 40, 'Playgame', "Verdana", 15);
tf2.autoSize = TextFieldAutoSize.HORIZONTAL;
tf2.border = true;
tf2.nativeFilters = [new DropShadowFilter(20, 180, 0xFF00F0, 1, 1, 1, 1)]
addChild(tf2);
tf2.x = 50;
tf2.y = 80;

// autoscale bug
var tf3:TextField = new TextField(100, 40, 'Playgame', "Verdana", 45);
tf3.autoScale = true;
tf3.border = true;
tf3.nativeFilters = [new DropShadowFilter(20, 180, 0xFF00F0, 1, 1, 1, 1)]
addChild(tf3);
tf3.x = 50;
tf3.y = 140;

```

![untitled-1](https://cloud.githubusercontent.com/assets/13777825/9568811/70826964-4f5e-11e5-9ea8-9119b232fd19.png)
