### PR TITLE
Convert to PMA at the shader if needed and wanted (#762)

### DIFF
--- a/starling/src/starling/core/Starling.as
+++ b/starling/src/starling/core/Starling.as
@@ -39,7 +39,7 @@ package starling.core
     import flash.utils.Dictionary;
     import flash.utils.getTimer;
     import flash.utils.setTimeout;
-
+    
     import starling.animation.Juggler;
     import starling.display.DisplayObject;
     import starling.display.Stage;
@@ -211,6 +211,7 @@ package starling.core
         private var mStarted:Boolean;
         private var mRendering:Boolean;
         private var mSupportHighResolutions:Boolean;
+		private var mConvertToPMA:Boolean;
         
         private var mViewPort:Rectangle;
         private var mPreviousViewPort:Rectangle;
@@ -1086,7 +1087,21 @@ package starling.core
                 if (contextValid) updateViewPort(true);
             }
         }
-        
+		
+		/** Indicates that if a texture is not premultipliedAlpha (ie: ATF textures in particular), 
+		 *  Starling will convert it to pma in the fragment shader. Note that it will add a MUL op
+		 *  in the shader for each pixel of theses textures. Activating this flag will fix issues
+		 *  with theses textures for some blend modes (like additive blend mode).
+		 *  @default false */
+		public function get convertToPMA():Boolean { return mConvertToPMA; }
+		public function set convertToPMA(value:Boolean):void 
+		{
+			if (mConvertToPMA != value)
+			{
+				mConvertToPMA = value;
+			}
+		}
+		
         /** The TouchProcessor is passed all mouse and touch input and is responsible for
          *  dispatching TouchEvents to the Starling display tree. If you want to handle these
          *  types of input manually, pass your own custom subclass to this property. */

--- a/starling/src/starling/display/BlendMode.as
+++ b/starling/src/starling/display/BlendMode.as
@@ -12,6 +12,7 @@ package starling.display
 {
     import flash.display3D.Context3DBlendFactor;
     
+    import starling.core.Starling;
     import starling.errors.AbstractClassError;
     
     /** A class that provides constant values for visual blend mode effects. 
@@ -101,6 +102,9 @@ package starling.display
          *  value. Throws an ArgumentError if the mode does not exist. */
         public static function getBlendFactors(mode:String, premultipliedAlpha:Boolean=true):Array
         {
+			if ( Starling.current.convertToPMA )
+				premultipliedAlpha = true;
+			
             var modes:Object = sBlendFactors[int(premultipliedAlpha)];
             if (mode in modes) return modes[mode];
             else throw new ArgumentError("Invalid blend mode");


### PR DESCRIPTION
Hi Daniel,

I tried to be a little invasive as possible and to follow your "style".
I added a flag on starling to request the non PMA texture to be converted to PMA, false by default so it should keep the old code exactly as fast as before.
If the flag is set to true, then It'll convert the non PMA texture to PMA in the shader and force blending to consider everything as PMA (regardless of the original texture format).

It fix all our blending issues.

Thanks for your time (Simas told me that v2-beta is across the corner, can't wait!)

Seb