### PR TITLE
Update AssetManager.as

### DIFF
--- a/starling/src/starling/utils/AssetManager.as
+++ b/starling/src/starling/utils/AssetManager.as
@@ -747,6 +747,7 @@ package starling.utils
                 removeEventListener(Event.CANCEL, cancel);
                 mNumLoadingQueues--;
                 canceled = true;
+                onProgress = null;
             }
 
             function finish():void
@@ -761,6 +762,7 @@ package starling.utils
                     {
                         cancel();
                         onProgress(1.0);
+                        onProgress = null;
                     }
                 }, 1);
             }

--- a/starling/src/starling/utils/AssetManager.as
+++ b/starling/src/starling/utils/AssetManager.as
@@ -747,7 +747,6 @@ package starling.utils
                 removeEventListener(Event.CANCEL, cancel);
                 mNumLoadingQueues--;
                 canceled = true;
-                onProgress = null;
             }
 
             function finish():void


### PR DESCRIPTION
I'm not sure why this is a problem, but I spent all morning tracking down a small memory leak and was able to trace it to this. The expected behavior of the variable "onProgress", is that it would lose scope and lose its reference from the calling object as soon as the loadQueue method completes, but for some reason when loading remote assets, it doesn't. 
When loading remote assets (http://<some-asset.mp3>), a reference is kept to the calling class's onProgress method which prevents the calling class from being garbage collected. 

example: SampleClass will not be garbage collected because a reference to "reportProgress" exists in AssetManager
class SampleClass {
	function beginLoading():void {
	  function reportProgress(ratio:Number):void {
			if (ratio >= 1.0) {
				doSomething();
			}
		}
		assetManager.enqueue(<my-mp3-file.mp3>);
		assetManager.loadQueue(reportProgress);
	}
}