### PR TITLE
#3669 Error: Bad Input Size

### DIFF
--- a/starling/src/starling/core/Starling.as
+++ b/starling/src/starling/core/Starling.as
@@ -587,7 +587,8 @@ package starling.core
                                              wantsBestResolution:Boolean=false):void
         {
             enableDepthAndStencil &&= SystemUtil.supportsDepthAndStencil;
-
+            width = (width < 32) ? 32 : width;
+            height = (height < 32) ? 32 : height;
             var configureBackBuffer:Function = mContext.configureBackBuffer;
             var methodArgs:Array = [width, height, antiAlias, enableDepthAndStencil];
             if (configureBackBuffer.length > 4) methodArgs.push(wantsBestResolution);


### PR DESCRIPTION
The minimum size of the buffer is 32x32 pixels. 
Description: http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/display3D/Context3D.html#configureBackBuffer()