### PR TITLE
Fix gradle build

### DIFF
--- a/starling/build/gradle/build.gradle
+++ b/starling/build/gradle/build.gradle
@@ -141,6 +141,8 @@ task compile(type: JavaExec) {
     def airConfig = "${AIR_HOME}" + '/frameworks/air-config.xml'
     def loadAirConfig = '-load-config+='+"${airConfig}";
     argsList.push(loadAirConfig)
+    argsList.push('-target-player=19.0')
+    argsList.push('-swf-version=31')
     args = argsList
 }
 
@@ -156,6 +158,8 @@ task compileTest(type: JavaExec) {
     argsList.push("-output=${buildDir}/tests.swf")
     argsList.push("-library-path+=${binDir}");
     argsList.push("-library-path+=${FLEX_HOME}/frameworks/libs");
+    argsList.push('-target-player=19.0')
+    argsList.push('-swf-version=31')
     argsList.push('-static-link-runtime-shared-libraries=true')
     args = argsList
 }


### PR DESCRIPTION
Test task hanged because of `ReferenceError: Error #1069: Property profile not found on flash.display3D.Context3D and there is no default value.` This property was added in some newer version of FP, but because the build was using 11.1, it wasn't available.

Cheers!