### PR TITLE
[~] Added a returnPlay property to MovieClip.

### DIFF
--- a/starling/src/starling/display/MovieClip.as
+++ b/starling/src/starling/display/MovieClip.as
@@ -49,6 +49,7 @@ package starling.display
         private var _currentTime:Number;
         private var _currentFrameID:int;
         private var _loop:Boolean;
+		private var _returnPlay:Boolean;
         private var _playing:Boolean;
         private var _muted:Boolean;
         private var _wasStopped:Boolean;
@@ -102,7 +103,10 @@ package starling.display
         {
             if (frameID < 0 || frameID > numFrames) throw new ArgumentError("Invalid frame id");
             if (duration < 0) duration = _defaultFrameDuration;
-
+			
+			var returnPlayActive:Boolean = returnPlay;
+			if (returnPlayActive) returnPlay = false;
+			
             var frame:MovieClipFrame = new MovieClipFrame(texture, duration);
             frame.sound = sound;
             _frames.insertAt(frameID, frame);
@@ -113,8 +117,9 @@ package starling.display
                 var prevDuration:Number  = frameID > 0 ? _frames[frameID - 1].duration  : 0.0;
                 frame.startTime = prevStartTime + prevDuration;
             }
-            else
-                updateStartTimes();
+            else updateStartTimes();
+			
+			if (returnPlayActive) returnPlay = true;
         }
         
         /** Removes the frame at a certain ID. The successors will move down. */
@@ -122,11 +127,14 @@ package starling.display
         {
             if (frameID < 0 || frameID >= numFrames) throw new ArgumentError("Invalid frame id");
             if (numFrames == 1) throw new IllegalOperationError("Movie clip must not be empty");
-
+			
+			var returnPlayActive:Boolean = returnPlay;
+			if (returnPlayActive) returnPlay = false;
+			
             _frames.removeAt(frameID);
 
-            if (frameID != numFrames)
-                updateStartTimes();
+            if (frameID != numFrames) updateStartTimes();
+			if (returnPlayActive) returnPlay = true;
         }
         
         /** Returns the texture of a certain frame. */
@@ -349,12 +357,15 @@ package starling.display
         // properties
 
         /** The total number of frames. */
-        public function get numFrames():int { return _frames.length; }
+        public function get numFrames():int
+		{
+			if (!_returnPlay) { return _frames.length } else { return _frames.length * 0.5 };
+		}
         
         /** The total duration of the clip in seconds. */
         public function get totalTime():Number 
         {
-            var lastFrame:MovieClipFrame = _frames[_frames.length-1];
+			var lastFrame:MovieClipFrame = (!_returnPlay) ? _frames[_frames.length-1] : _frames[(_frames.length * 0.5) - 1];
             return lastFrame.startTime + lastFrame.duration;
         }
         
@@ -379,6 +390,33 @@ package starling.display
         public function get loop():Boolean { return _loop; }
         public function set loop(value:Boolean):void { _loop = value; }
         
+		/** Indicates if the clip should play forwards, then in reverse. @default false */
+		public function get returnPlay():Boolean { return _returnPlay; }
+		public function set returnPlay(value:Boolean):void {
+			if (_returnPlay != value)
+			{		
+				var numFrames:int = _frames.length;
+				
+				if (value)
+				{
+					for (var i:int = numFrames - 1; i >= 0; i--)
+					{
+						addFrame(_frames[i].texture, _frames[i].sound, _frames[i].duration);
+					}					
+					_returnPlay = true;
+				} else {
+					_returnPlay = false;
+					var halfNumFrames:int = numFrames * 0.5;
+					if (_currentFrameID >= halfNumFrames) currentFrame = ((numFrames * 0.5) - (_currentFrameID - (numFrames * 0.5))) - 1;
+					
+					for (i = numFrames - 1; i >= halfNumFrames; i--)
+					{
+						removeFrameAt(i);
+					}
+				}
+			}
+		}
+		
         /** If enabled, no new sounds will be started during playback. Sounds that are already
          *  playing are not affected. */
         public function get muted():Boolean { return _muted; }
@@ -389,7 +427,11 @@ package starling.display
         public function set soundTransform(value:SoundTransform):void { _soundTransform = value; }
 
         /** The index of the frame that is currently displayed. */
-        public function get currentFrame():int { return _currentFrameID; }
+        public function get currentFrame():int {
+			if (!_returnPlay) return _currentFrameID;
+			if (_currentFrameID < _frames.length * 0.5) return _currentFrameID;
+			return numFrames - (_currentFrameID - numFrames) - 1;
+		}
         public function set currentFrame(value:int):void
         {
             if (value < 0 || value >= numFrames) throw new ArgumentError("Invalid frame id");


### PR DESCRIPTION
This is a feature I've put into a current project.  When enabled, the clip will play to the end, then effectively play in reverse back to the start, in a back-forth way.  I thought I'd see if it could be worked into the MovieClip class as a built in property.

In effect, it replicates the existing frames and adds them in reverse to the MovieClipFrames vector.

In handling things like numFrames and currentFrame, I've obscured the return value to only reflect the original clip.  The reasoning is I thought it'd be easier for people to continue treating the clip as unchanged in length and framecount, it simply plays in reverse when it gets to the end.

I'm uncertain if currentTime should be obscured in the same way, my gut feeling is it should remain unobscured, so the full play time back and forth, is twice the normal play time.

When adding and removing frames to a clip, if returnPlay is active, the logic works like this:
if (returnPlay == true)
returnPlay = false: remove the mirrored frames
add or remove frames
returnPlay = true: re-mirror the frames

There's perhaps a more elegant way to do this rather than destroying and re-creating all the mirrored frames each time, but it's not something I anticipate needs to be done too frequently so I've left it for now.

Known quirks: The first and last frames of the clip are doubled.  I'm not sure if this is an issue, or expected behaviour?