### PR TITLE
Software RenderMode does not support high resolution

### DIFF
--- a/starling/src/starling/core/Starling.as
+++ b/starling/src/starling/core/Starling.as
@@ -948,6 +948,8 @@ package starling.core
         public function get supportHighResolutions():Boolean { return _supportHighResolutions; }
         public function set supportHighResolutions(value:Boolean):void 
         {
+            if (context && context.driverInfo.indexOf("Software") != -1) return;
+
             if (_supportHighResolutions != value)
             {
                 _supportHighResolutions = value;


### PR DESCRIPTION
If you set Starling.supportHighResolutions to true on a high resolution screen, such as a MacBook Retina, while in Software mode you get an exception:

`exception, information=Error: Error #3780: Requested width of backbuffer is not in allowed range 32 to 2048.`

This fix also applies to Starling 1.8.