### PR TITLE
add Strength property to the filter

### DIFF
--- a/starling/src/starling/filters/BlurFilter.as
+++ b/starling/src/starling/filters/BlurFilter.as
@@ -20,6 +20,7 @@ package starling.filters
     {
         private var _blurX:Number;
         private var _blurY:Number;
+        private var _strength:Number = 1;
 
         /** Create a new BlurFilter. For each blur direction, the number of required passes is
          *  <code>Math.ceil(blur)</code>.
@@ -31,10 +32,11 @@ package starling.filters
          *      <li>etc.</li>
          *  </ul>
          */
-        public function BlurFilter(blurX:Number=1.0, blurY:Number=1.0, resolution:Number=1.0)
+        public function BlurFilter(blurX:Number=1.0, blurY:Number=1.0, strength:Number = 1.0, resolution:Number=1.0)
         {
             _blurX = blurX;
             _blurY = blurY;
+            _strength = strength;
             this.resolution = resolution;
         }
 
@@ -51,6 +53,7 @@ package starling.filters
                 return super.process(painter, helper, input0);
             }
 
+            effect.saturation = _strength;
             var blurX:Number = Math.abs(_blurX);
             var blurY:Number = Math.abs(_blurY);
             var outTexture:Texture = input0;
@@ -129,6 +132,17 @@ package starling.filters
             _blurY = value;
             updatePadding();
         }
+
+		public function get strength():Number
+        {
+            return _strength;
+        }
+
+        public function set strength(value:Number):void
+        {
+            _strength=value;
+            updatePadding();
+        }
     }
 }
 
@@ -149,6 +163,7 @@ class BlurEffect extends FilterEffect
     private var _strength:Number;
     private var _direction:String;
 
+    private var _saturations:Vector.<Number> = new <Number>[1.0, 0, 0, 0];
     private var _offsets:Vector.<Number> = new <Number>[0, 0, 0, 0];
     private var _weights:Vector.<Number> = new <Number>[0, 0, 0, 0];
 
@@ -203,7 +218,9 @@ class BlurEffect extends FilterEffect
 
             tex("ft4", "v4", 0, texture),    // read pixel +2
             "mul ft4, ft4, fc0.zzzz       ", // multiply with weight
-            "add  oc, ft5, ft4            "  // add to output color
+            "add  ft5, ft5, ft4 ",
+            "mul oc, ft5, fc1.xxxx"
+
         ].join("\n");
 
         return Program.fromSource(vertexShader, fragmentShader);
@@ -219,6 +236,7 @@ class BlurEffect extends FilterEffect
 
             context.setProgramConstantsFromVector(Context3DProgramType.VERTEX,   4, _offsets);
             context.setProgramConstantsFromVector(Context3DProgramType.FRAGMENT, 0, _weights);
+            context.setProgramConstantsFromVector(Context3DProgramType.FRAGMENT, 1, _saturations);
         }
     }
 
@@ -292,6 +310,8 @@ class BlurEffect extends FilterEffect
             _offsets[2] = 0;
             _offsets[3] = offset2;
         }
+
+
     }
 
     public function get direction():String { return _direction; }
@@ -302,4 +322,9 @@ class BlurEffect extends FilterEffect
     {
         _strength = MathUtil.clamp(value, 0, 1);
     }
+
+    public function get saturation():Number { return _saturations[0]; }
+    public function set saturation(value:Number):void { _saturations[0] = value; }
+
+
 }

--- a/starling/src/starling/filters/DropShadowFilter.as
+++ b/starling/src/starling/filters/DropShadowFilter.as
@@ -26,11 +26,11 @@ package starling.filters
 
         /** Creates a new DropShadowFilter instance with the specified parameters. */
         public function DropShadowFilter(distance:Number=4.0, angle:Number=0.785,
-                                         color:uint=0x0, alpha:Number=0.5, blur:Number=1.0,
+                                         color:uint=0x0, alpha:Number=0.5, blur:Number=1.0, strength:Number = 1.0,
                                          resolution:Number=0.5)
         {
             _compositeFilter = new CompositeFilter();
-            _blurFilter = new BlurFilter(blur, blur, resolution);
+            _blurFilter = new BlurFilter(blur, blur, strength, resolution);
             _distance = distance;
             _angle = angle;
 

--- a/starling/src/starling/filters/GlowFilter.as
+++ b/starling/src/starling/filters/GlowFilter.as
@@ -22,11 +22,10 @@ package starling.filters
         private var _compositeFilter:CompositeFilter;
 
         /** Initializes a new GlowFilter instance with the specified parameters. */
-        public function GlowFilter(color:uint=0xffff00, alpha:Number=1.0, blur:Number=1.0,
-                                   resolution:Number=0.5)
+        public function GlowFilter(color:uint=0xffff00, alpha:Number=1.0, blur:Number=1.0, strength:Number = 1.0, resolution:Number=0.5)
         {
             _compositeFilter = new CompositeFilter();
-            _blurFilter = new BlurFilter(blur, blur, resolution);
+            _blurFilter = new BlurFilter(blur, blur, strength, resolution);
 
             this.color = color;
             this.alpha = alpha;
@@ -107,6 +106,16 @@ package starling.filters
             if (resolution != value)
             {
                 _blurFilter.resolution = value;
+                updatePadding();
+            }
+        }
+        
+        public function get strength():Number { return _blurFilter.strength; }
+        public function set strength(value:Number):void
+        {
+            if (_blurFilter.strength != value)
+            {
+                _blurFilter.strength = value;
                 updatePadding();
             }
         }


### PR DESCRIPTION
Add strength property to the filters like in the native flash filter.

With this property you can make stroke for the text
![flash_example](https://cloud.githubusercontent.com/assets/11671104/14886735/0bc0b9ca-0d5b-11e6-83da-8ac7e959c60c.png)

![starling_example](https://cloud.githubusercontent.com/assets/11671104/14886749/2102b41e-0d5b-11e6-85e3-22f07ab2224d.png)

var textField:TextField = new TextField(400,200, "Hello World");
textField.format.setTo("DR Agu", 60, 0xFF0000);
textField.x = 50;
textField.y = 50;
textField.filter = new GlowFilter(0x000000, 1, 0.5, 2.5, 1);
addChild(textField);