### PR TITLE
Ignore texture scale wthen create a BitmapFont

### DIFF
--- a/starling/src/starling/text/BitmapFont.as
+++ b/starling/src/starling/text/BitmapFont.as
@@ -81,7 +81,7 @@ package starling.text
         
         /** Creates a bitmap font by parsing an XML file and uses the specified texture. 
          *  If you don't pass any data, the "mini" font will be created. */
-        public function BitmapFont(texture:Texture=null, fontXml:XML=null)
+        public function BitmapFont(texture:Texture=null, fontXml:XML=null, ignoreTextureScale:Boolean=false)
         {
             // if no texture is passed in, we create the minimal, embedded font
             if (texture == null && fontXml == null)
@@ -101,7 +101,7 @@ package starling.text
             mChars = new Dictionary();
             mHelperImage = new Image(texture);
             
-            parseFontXml(fontXml);
+            parseFontXml(fontXml, ignoreTextureScale);
         }
         
         /** Disposes the texture of the bitmap font! */
@@ -111,9 +111,9 @@ package starling.text
                 mTexture.dispose();
         }
         
-        private function parseFontXml(fontXml:XML):void
+        private function parseFontXml(fontXml:XML, ignoreTextureScale: Boolean):void
         {
-            var scale:Number = mTexture.scale;
+            var scale:Number = ignoreTextureScale ? 1 : mTexture.scale;
             var frame:Rectangle = mTexture.frame;
             var frameX:Number = frame ? frame.x : 0;
             var frameY:Number = frame ? frame.y : 0;


### PR DESCRIPTION
Sometimes scale coordinates is bad idea. I heve no ideas how to fix it otherwise. Thanks.

![badfont](https://cloud.githubusercontent.com/assets/1662527/14923342/4e29fed0-0e45-11e6-8b9b-685992b97692.PNG)

![goodfont](https://cloud.githubusercontent.com/assets/1662527/14923358/7049d24c-0e45-11e6-9481-15e6e569b14c.PNG)
