### PR TITLE
Added ability to manually restore TextureBase.

### DIFF
--- a/starling/src/starling/textures/ConcreteTexture.as
+++ b/starling/src/starling/textures/ConcreteTexture.as
@@ -18,8 +18,9 @@ package starling.textures
     import flash.system.Capabilities;
     import flash.utils.ByteArray;
     import flash.utils.getQualifiedClassName;
-
+    
     import starling.core.Starling;
+    import starling.core.starling_internal;
     import starling.errors.AbstractClassError;
     import starling.errors.AbstractMethodError;
     import starling.errors.NotSupportedError;
@@ -163,6 +164,12 @@ package starling.textures
         {
             throw new AbstractMethodError();
         }
+		
+		/** Create TextureBase object. This function uses only for manual restoring of textures. */		
+		starling_internal function initBase():void
+		{
+			_base = createBase(); 
+		}
         
         /** Clears the texture with a certain color and alpha value. The previous contents of the
          *  texture is wiped out. */


### PR DESCRIPTION
Hi,

We are working on Firefly Framework http://firefly.in4ray.com/ and for our new version we need ability to manually restore TextureBase object in textures that will be used by our Texture State managment functionality. Please merge if it acceptable for you.

We asked you to do the same for previous version of Starling (https://github.com/Gamua/Starling-Framework/pull/386). It's important for us because we want to migrate the platform to Starling 2.0.

Thx in advance,
Roman Zarichnyi