### PR TITLE
More data consistency

### DIFF
--- a/starling/src/starling/text/BitmapFont.as
+++ b/starling/src/starling/text/BitmapFont.as
@@ -90,7 +90,7 @@ package starling.text
                 texture = MiniBitmapFont.texture;
                 fontXml = MiniBitmapFont.xml;
             }
-            else if (texture != null && fontXml == null)
+            else if (texture == null || fontXml == null)
             {
                 throw new ArgumentError("fontXml cannot be null!");
             }

--- a/starling/src/starling/text/BitmapFont.as
+++ b/starling/src/starling/text/BitmapFont.as
@@ -92,7 +92,7 @@ package starling.text
             }
             else if (texture == null || fontXml == null)
             {
-                throw new ArgumentError("fontXml cannot be null!");
+                throw new ArgumentError("Set both of the 'texture' and 'fontXml' arguments to valid objects or leave both of them null.");
             }
             
             _name = "unknown";


### PR DESCRIPTION
The "texture" is a through-constructor initialized immutable field. The case of which the two arguments are <code>null</code> is the "default" approach to utilize the "minimal" embedded font, and the "typical" case is when the two arguments are provided correctly. The <code>else</code> statement is to assert for data consistency and considering the current implementation, there is no chance to "set" the "texture" nor the "XML" later, so both of them need to be provided "not <code>null</code>" initially. However, only the specific case of the <code>texture != null && fontXml == null</code> is evaluated leaving the case of <code>texture == null && fontXml != null</code> unregarded! To compensate the issue, change the criteria to <code>texture == null || fontXml == null</code> to regard the both of the "wrong" cases :)