### PR TITLE
On Windows, setRequiresRedraw() is required when resizing view port or Starling stage after resizing NativeWindow and skipUnchangedFrames is true

### DIFF
--- a/starling/src/starling/core/Starling.as
+++ b/starling/src/starling/core/Starling.as
@@ -797,7 +797,11 @@ package starling.core
         
         /** The viewport into which Starling contents will be rendered. */
         public function get viewPort():Rectangle { return _viewPort; }
-        public function set viewPort(value:Rectangle):void { _viewPort = value.clone(); }
+        public function set viewPort(value:Rectangle):void
+        {
+            _viewPort = value.clone();
+            _stage.setRequiresRedraw();
+        }
         
         /** The ratio between viewPort width and stage width. Useful for choosing a different
          *  set of textures depending on the display resolution. */

--- a/starling/src/starling/display/Stage.as
+++ b/starling/src/starling/display/Stage.as
@@ -281,12 +281,20 @@ package starling.display
         /** The width of the stage coordinate system. Change it to scale its contents relative
          *  to the <code>viewPort</code> property of the Starling object. */ 
         public function get stageWidth():int { return _width; }
-        public function set stageWidth(value:int):void { _width = value; }
+        public function set stageWidth(value:int):void
+        {
+            _width = value;
+            setRequiresRedraw();
+        }
         
         /** The height of the stage coordinate system. Change it to scale its contents relative
          *  to the <code>viewPort</code> property of the Starling object. */
         public function get stageHeight():int { return _height; }
-        public function set stageHeight(value:int):void { _height = value; }
+        public function set stageHeight(value:int):void
+        {
+            _height = value;
+            setRequiresRedraw();
+        }
 
         /** The Starling instance this stage belongs to. */
         public function get starling():Starling


### PR DESCRIPTION
I was able to confirm the following issue reported by a couple of users in the forums. It worked correctly on my Mac, but when I tried on Windows 10, increasing the dimensions of the NativeWindow resulted in white regions on the edges. I'm not sure why it works on one platform, and not the other.

The following post in the thread includes a screenshot and some MXML code for the Feathers SDK that will reproduce the issue (I'm sure it's easy to reproduce purely with Starling and another SDK, though):

http://forum.starling-framework.org/topic/feathers-background-not-resizing/page/2#post-94362

When I added calls to setRequiresRedraw() either to Starling's viewPort property or to Stage's stageWidth and stageHeight properties, I could no longer reproduce the issue. For safety, I think the call to setRequiresRedraw() should be included in both places, because there may be a rare situation where a developer might change the view port or the stage dimensions, but not both.