### PR TITLE
Small MeshBatch Fix

### DIFF
--- a/starling/src/starling/display/MeshBatch.as
+++ b/starling/src/starling/display/MeshBatch.as
@@ -187,9 +187,15 @@ package starling.display
             var meshStyleType:Class = meshStyle.type;
 
             if (_style.type != meshStyleType)
-                setStyle(new meshStyleType() as MeshStyle, false);
-
-            _style.copyFrom(meshStyle);
+            {
+                var newStyle:MeshStyle = new meshStyleType() as MeshStyle;
+                newStyle.copyFrom(meshStyle);
+                setStyle(newStyle, false);
+            }
+            else
+            {
+                _style.copyFrom(meshStyle);
+            }
         }
 
         /** Indicates if the given mesh instance fits to the current state of the batch.


### PR DESCRIPTION
I've created an Effect that depends on the state of its parent Style for program creation. This fix just ensures that the style is copied _before_ a new style is set on a batch.