### PR TITLE
initialized helper matrix to reduce allocations

### DIFF
--- a/starling/src/starling/filters/FragmentFilter.as
+++ b/starling/src/starling/filters/FragmentFilter.as
@@ -111,7 +111,7 @@ package starling.filters
         private var _cached:Boolean;
 
         // helpers
-        private static var sMatrix3D:Matrix3D;
+        private static var sMatrix3D:Matrix3D = new Matrix3D();
 
         /** Creates a new instance. The base class' implementation just draws the unmodified
          *  input texture. */


### PR DESCRIPTION
Noticed a number of Matrix3D allocations in filters and thought this should have been initialized.