### PR TITLE
EventDispatcher: try to avoid creating a duplicate Vector.<Function> in removeEventListener

### DIFF
--- a/starling/src/starling/events/EventDispatcher.as
+++ b/starling/src/starling/events/EventDispatcher.as
@@ -38,6 +38,7 @@ package starling.events
     public class EventDispatcher
     {
         private var _eventListeners:Dictionary;
+        private var _eventStack:Vector.<String> = new <String>[];
         
         /** Helper object. */
         private static var sBubbleChains:Array = [];
@@ -76,12 +77,19 @@ package starling.events
 
                     if (index != -1)
                     {
-                        var restListeners:Vector.<Function> = listeners.slice(0, index);
+                        if(_eventStack.indexOf(type) == -1)
+                        {
+                            listeners.removeAt(index);
+                        }
+                        else
+                        {
+                            var restListeners:Vector.<Function> = listeners.slice(0, index);
 
-                        for (var i:int=index+1; i<numListeners; ++i)
-                            restListeners[i-1] = listeners[i];
+                            for (var i:int=index+1; i<numListeners; ++i)
+                                restListeners[i-1] = listeners[i];
 
-                        _eventListeners[type] = restListeners;
+                            _eventListeners[type] = restListeners;
+                        }
                     }
                 }
             }
@@ -133,6 +141,7 @@ package starling.events
             if (numListeners)
             {
                 event.setCurrentTarget(this);
+                _eventStack[_eventStack.length] = event.type;
                 
                 // we can enumerate directly over the vector, because:
                 // when somebody modifies the list while we're looping, "addEventListener" is not
@@ -150,6 +159,8 @@ package starling.events
                     if (event.stopsImmediatePropagation)
                         return true;
                 }
+
+                _eventStack.pop();
                 
                 return event.stopsPropagation;
             }


### PR DESCRIPTION
Hey, Daniel! As you know, removeEventListener() creates a copy of the Vector.&lt;Function&gt; that contains every listener for a certain event type. This is to ensure that events currently being dispatched will reach all listeners that were added at the time of the dispatchEvent() call. Removing a listener should only affect future dispatchEvent() calls.

I don't think it's necessary to create a duplicate Vector.&lt;Function&gt; every time that removeEventListener() is called, though. If an event is not currently being dispatched, there should be no risk from modifying the original Vector.&lt;Function&gt; directly.

My proposed optimization is to keep a stack of event types currently being dispatched. If the event type passed to removeEventListener() is in the stack, Starling will create a duplicate Vector.&lt;Function&gt;, just like it does today. If the event type is not in the stack, no duplicate is created and the original Vector.&lt;Function&gt; is modified directly.

I've included a screenshot of the Deallocations view in Scout. I was running the Feathers Components Explorer example, and I simply navigated back and forth between the main menu screen and a screen containing a GroupedList component several times.

![deallocations](https://cloud.githubusercontent.com/assets/141885/22343840/7bdc436c-e3ae-11e6-9e3a-76ff37cda31a.jpg)

The top half of the screenshot shows Starling's current behavior where a duplicate Vector.&lt;Function&gt; is created every time. The bottom half shows my modified version of EventDispatcher that modifies the original Vector.&lt;Function&gt;, if possible.

As you can see, Vector.&lt;Function&gt; started out as the second most deallocated object in my test. After my modifications, less than half the number of Vector.&lt;Function&gt; instances were deallocated, and it dropped below Array to third place.