### PR TITLE
better Object Oriented scheme

### DIFF
--- a/starling/src/starling/textures/TextureAtlas.as
+++ b/starling/src/starling/textures/TextureAtlas.as
@@ -71,9 +71,9 @@ package starling.textures
      */
     public class TextureAtlas
     {
-        private var _atlasTexture:Texture;
-        private var _subTextures:Dictionary;
-        private var _subTextureNames:Vector.<String>;
+        protected var _atlasTexture:Texture;
+        protected var _subTextures:Dictionary;
+        protected var _subTextureNames:Vector.<String>;
         
         /** helper objects */
         private static var sNames:Vector.<String> = new <String>[];
@@ -213,7 +213,7 @@ package starling.textures
         
         // utility methods
 
-        private static function parseBool(value:String):Boolean
+        protected static function parseBool(value:String):Boolean
         {
             return value.toLowerCase() == "true";
         }

--- a/starling/src/starling/textures/TextureAtlas.as
+++ b/starling/src/starling/textures/TextureAtlas.as
@@ -71,9 +71,9 @@ package starling.textures
      */
     public class TextureAtlas
     {
-        protected var _atlasTexture:Texture;
-        protected var _subTextures:Dictionary;
-        protected var _subTextureNames:Vector.<String>;
+        private var _atlasTexture:Texture;
+        private var _subTextures:Dictionary;
+        private var _subTextureNames:Vector.<String>;
         
         /** helper objects */
         private static var sNames:Vector.<String> = new <String>[];
@@ -198,6 +198,13 @@ package starling.textures
             _subTextures[name] = new SubTexture(_atlasTexture, region, false, frame, rotated);
             _subTextureNames = null;
         }
+        
+        /** Adds a named region for an instance of SubTexture or an instance of its sub-classes.*/
+		public function addSubTexture(name:String, subTexture:SubTexture):void
+		{
+            _subTextures[name] = subTexture;
+            _subTextureNames = null;
+		}
         
         /** Removes a region with a certain name. */
         public function removeRegion(name:String):void

--- a/starling/src/starling/textures/TextureAtlas.as
+++ b/starling/src/starling/textures/TextureAtlas.as
@@ -200,11 +200,11 @@ package starling.textures
         }
         
         /** Adds a named region for an instance of SubTexture or an instance of its sub-classes.*/
-		public function addSubTexture(name:String, subTexture:SubTexture):void
-		{
+        public function addSubTexture(name:String, subTexture:SubTexture):void
+        {
             _subTextures[name] = subTexture;
             _subTextureNames = null;
-		}
+        }
         
         /** Removes a region with a certain name. */
         public function removeRegion(name:String):void


### PR DESCRIPTION
Changed the <code>private</code> access modifiers to <code>protected</code> to enforce the OOP practices. By changing the fields' access modifiers to <code>protected</code>, one can customize the implementation while still utilizing the same interface.