### PR TITLE
Include the name of the class when throwing an error

### DIFF
--- a/starling/src/starling/animation/Juggler.as
+++ b/starling/src/starling/animation/Juggler.as
@@ -237,7 +237,7 @@ package starling.animation
          */
         public function delayCall(call:Function, delay:Number, ...args):uint
         {
-            if (call == null) throw new ArgumentError("call must not be null");
+            if (call == null) throw new ArgumentError(outputName + " call must not be null");
             
             var delayedCall:DelayedCall = DelayedCall.starling_internal::fromPool(call, delay, args);
             delayedCall.addEventListener(Event.REMOVE_FROM_JUGGLER, onPooledDelayedCallComplete);
@@ -252,7 +252,7 @@ package starling.animation
          */
         public function repeatCall(call:Function, interval:Number, repeatCount:int=0, ...args):uint
         {
-            if (call == null) throw new ArgumentError("call must not be null");
+            if (call == null) throw new ArgumentError(outputName + " call must not be null");
             
             var delayedCall:DelayedCall = DelayedCall.starling_internal::fromPool(call, interval, args);
             delayedCall.repeatCount = repeatCount;
@@ -299,7 +299,7 @@ package starling.animation
          */
         public function tween(target:Object, time:Number, properties:Object):uint
         {
-            if (target == null) throw new ArgumentError("target must not be null");
+            if (target == null) throw new ArgumentError(outputName + " target must not be null");
 
             var tween:Tween = Tween.starling_internal::fromPool(target, time);
             
@@ -312,7 +312,7 @@ package starling.animation
                 else if (target.hasOwnProperty(Tween.getPropertyName(property)))
                     tween.animate(property, value as Number);
                 else
-                    throw new ArgumentError("Invalid property: " + property);
+                    throw new ArgumentError(outputName + " Invalid property: " + property);
             }
             
             tween.addEventListener(Event.REMOVE_FROM_JUGGLER, onPooledTweenComplete);
@@ -392,5 +392,7 @@ package starling.animation
  
         /** The actual vector that contains all objects that are currently being animated. */
         protected function get objects():Vector.<IAnimatable> { return _objects; }
+
+        private static function get outputName():String { return "[Juggler]"; }
     }
 }

--- a/starling/src/starling/animation/Tween.as
+++ b/starling/src/starling/animation/Tween.as
@@ -106,7 +106,8 @@ package starling.animation
             else if (transition is Function)
                 this.transitionFunc = transition as Function;
             else 
-                throw new ArgumentError("Transition must be either a string or a function");
+                throw new ArgumentError(outputName + " Transition must be either a string or a " +
+				                        "function");
             
             if (_properties)  _properties.length  = 0; else _properties  = new <String>[];
             if (_startValues) _startValues.length = 0; else _startValues = new <Number>[];
@@ -319,7 +320,7 @@ package starling.animation
         public function getEndValue(property:String):Number
         {
             var index:int = _properties.indexOf(property);
-            if (index == -1) throw new ArgumentError("The property '" + property + "' is not animated");
+            if (index == -1) throw new ArgumentError(outputName + " The property '" + property + "' is not animated");
             else return _endValues[index] as Number;
         }
         
@@ -340,7 +341,7 @@ package starling.animation
             _transitionFunc = Transitions.getTransition(value);
             
             if (_transitionFunc == null)
-                throw new ArgumentError("Invalid transiton: " + value);
+                throw new ArgumentError(outputName + " Invalid transiton: " + value);
         }
         
         /** The actual transition function used for the animation. */
@@ -423,6 +424,8 @@ package starling.animation
          *  this tween is completed. */
         public function get nextTween():Tween { return _nextTween; }
         public function set nextTween(value:Tween):void { _nextTween = value; }
+        
+        private static function get outputName():String { return "[Tween]"; }
         
         // tween pooling
         

--- a/starling/src/starling/core/Starling.as
+++ b/starling/src/starling/core/Starling.as
@@ -257,7 +257,7 @@ package starling.core
                                  viewPort:Rectangle=null, stage3D:Stage3D=null,
                                  renderMode:String="auto", profile:Object="auto")
         {
-            if (stage == null) throw new ArgumentError("Stage must not be null");
+            if (stage == null) throw new ArgumentError(outputName + " Stage must not be null");
             if (viewPort == null) viewPort = new Rectangle(0, 0, stage.stageWidth, stage.stageHeight);
             if (stage3D == null) stage3D = stage.stage3Ds[0];
 
@@ -367,7 +367,7 @@ package starling.core
             if (_root == null && _rootClass != null)
             {
                 _root = new _rootClass() as DisplayObject;
-                if (_root == null) throw new Error("Invalid root class: " + _rootClass);
+                if (_root == null) throw new Error(outputName + " Invalid root class: " + _rootClass);
                 _stage.addChildAt(_root, 0);
 
                 dispatchEventWith(starling.events.Event.ROOT_CREATED, false, _root);
@@ -520,7 +520,7 @@ package starling.core
             nativeOverlay.addChild(textField);
             stop(true);
 
-            trace("[Starling]", message);
+            trace(outputName, message);
             dispatchEventWith(starling.events.Event.FATAL_ERROR, false, message);
         }
         
@@ -876,12 +876,12 @@ package starling.core
                 if (horizontalAlign == Align.LEFT) _statsDisplay.x = 0;
                 else if (horizontalAlign == Align.RIGHT)  _statsDisplay.x =  stageWidth - _statsDisplay.width;
                 else if (horizontalAlign == Align.CENTER) _statsDisplay.x = (stageWidth - _statsDisplay.width) / 2;
-                else throw new ArgumentError("Invalid horizontal alignment: " + horizontalAlign);
+                else throw new ArgumentError(outputName + " Invalid horizontal alignment: " + horizontalAlign);
                 
                 if (verticalAlign == Align.TOP) _statsDisplay.y = 0;
                 else if (verticalAlign == Align.BOTTOM) _statsDisplay.y =  stageHeight - _statsDisplay.height;
                 else if (verticalAlign == Align.CENTER) _statsDisplay.y = (stageHeight - _statsDisplay.height) / 2;
-                else throw new ArgumentError("Invalid vertical alignment: " + verticalAlign);
+                else throw new ArgumentError(outputName + " Invalid vertical alignment: " + verticalAlign);
             }
             
             function onRootCreated():void
@@ -918,7 +918,7 @@ package starling.core
         public function set rootClass(value:Class):void
         {
             if (_rootClass != null && _root != null)
-                throw new Error("Root class may not change after root has been instantiated");
+                throw new Error(outputName + " Root class may not change after root has been instantiated");
             else if (_rootClass == null)
             {
                 _rootClass = value;
@@ -975,7 +975,7 @@ package starling.core
         public function get touchProcessor():TouchProcessor { return _touchProcessor; }
         public function set touchProcessor(value:TouchProcessor):void
         {
-            if (value == null) throw new ArgumentError("TouchProcessor must not be null");
+            if (value == null) throw new ArgumentError(outputName + " TouchProcessor must not be null");
             else if (value != _touchProcessor)
             {
                 _touchProcessor.dispose();
@@ -1022,7 +1022,7 @@ package starling.core
         public static function set multitouchEnabled(value:Boolean):void
         {
             if (sCurrent) throw new IllegalOperationError(
-                "'multitouchEnabled' must be set before Starling instance is created");
+                outputName + " 'multitouchEnabled' must be set before Starling instance is created");
             else 
                 Multitouch.inputMode = value ? MultitouchInputMode.TOUCH_POINT :
                                                MultitouchInputMode.NONE;
@@ -1033,6 +1033,8 @@ package starling.core
         {
             return sCurrent ? sCurrent._frameID : 0;
         }
+
+        private static function get outputName():String { return "[Starling]"; }
     }
 }
 

--- a/starling/src/starling/display/Button.as
+++ b/starling/src/starling/display/Button.as
@@ -69,7 +69,8 @@ package starling.display
         public function Button(upState:Texture, text:String="", downState:Texture=null,
                                overState:Texture=null, disabledState:Texture=null)
         {
-            if (upState == null) throw new ArgumentError("Texture 'upState' cannot be null");
+            if (upState == null) 
+                throw new ArgumentError(outputName + " Texture 'upState' cannot be null");
             
             _upState = upState;
             _downState = downState;
@@ -225,7 +226,7 @@ package starling.display
                     _contents.alpha = _alphaWhenDisabled;
                     break;
                 default:
-                    throw new ArgumentError("Invalid button state: " + _state);
+                    throw new ArgumentError(outputName + " Invalid button state: " + _state);
             }
         }
 
@@ -321,7 +322,7 @@ package starling.display
         public function set upState(value:Texture):void
         {
             if (value == null)
-                throw new ArgumentError("Texture 'upState' cannot be null");
+                throw new ArgumentError(outputName + " Texture 'upState' cannot be null");
 
             if (_upState != value)
             {
@@ -452,5 +453,7 @@ package starling.display
          */
         public function get scale9Grid():Rectangle { return _body.scale9Grid; }
         public function set scale9Grid(value:Rectangle):void { _body.scale9Grid = value; }
+
+        private static function get outputName():String { return "[Button]"; }
     }
 }

--- a/starling/src/starling/display/DisplayObject.as
+++ b/starling/src/starling/display/DisplayObject.as
@@ -379,12 +379,14 @@ package starling.display
             if (horizontalAlign == Align.LEFT)        _pivotX = bounds.x;
             else if (horizontalAlign == Align.CENTER) _pivotX = bounds.x + bounds.width / 2.0;
             else if (horizontalAlign == Align.RIGHT)  _pivotX = bounds.x + bounds.width;
-            else throw new ArgumentError("Invalid horizontal alignment: " + horizontalAlign);
+            else throw new ArgumentError(outputName + " Invalid horizontal alignment: " +
+                                         horizontalAlign);
             
             if (verticalAlign == Align.TOP)         _pivotY = bounds.y;
             else if (verticalAlign == Align.CENTER) _pivotY = bounds.y + bounds.height / 2.0;
             else if (verticalAlign == Align.BOTTOM) _pivotY = bounds.y + bounds.height;
-            else throw new ArgumentError("Invalid vertical alignment: " + verticalAlign);
+            else throw new ArgumentError(outputName + " Invalid vertical alignment: " + 
+                                         verticalAlign);
         }
 
         /** Draws the object into a BitmapData object.
@@ -530,7 +532,8 @@ package starling.display
         public function local3DToGlobal(localPoint:Vector3D, out:Point=null):Point
         {
             var stage:Stage = this.stage;
-            if (stage == null) throw new IllegalOperationError("Object not connected to stage");
+            if (stage == null) 
+                throw new IllegalOperationError(outputName + " Object not connected to stage");
 
             getTransformationMatrix3D(stage, sHelperMatrixAlt3D);
             MatrixUtil.transformPoint3D(sHelperMatrixAlt3D, localPoint, sHelperPoint3D);
@@ -543,7 +546,8 @@ package starling.display
         public function globalToLocal3D(globalPoint:Point, out:Vector3D=null):Vector3D
         {
             var stage:Stage = this.stage;
-            if (stage == null) throw new IllegalOperationError("Object not connected to stage");
+            if (stage == null) 
+                throw new IllegalOperationError(outputName + " Object not connected to stage");
 
             getTransformationMatrix3D(stage, sHelperMatrixAlt3D);
             sHelperMatrixAlt3D.invert();
@@ -562,8 +566,9 @@ package starling.display
                 ancestor = ancestor._parent;
             
             if (ancestor == this)
-                throw new ArgumentError("An object cannot be added as a child to itself or one " +
-                                        "of its children (or children's children, etc.)");
+                throw new ArgumentError(outputName + " An object cannot be added as a child " + 
+                                        "to itself or one of its children (or children's " +
+                                        "children, etc.)");
             else
                 _parent = value;
         }
@@ -661,7 +666,7 @@ package starling.display
             sAncestors.length = 0;
 
             if (currentObject) return currentObject;
-            else throw new ArgumentError("Object not connected to target");
+            else throw new ArgumentError(outputName + " Object not connected to target");
         }
 
         // stage event handling
@@ -1178,5 +1183,7 @@ package starling.display
         /** The stage the display object is connected to, or null if it is not connected 
          *  to the stage. */
         public function get stage():Stage { return this.base as Stage; }
+        
+        private static function get outputName():String { return "[DisplayObject]"; }
     }
 }

--- a/starling/src/starling/utils/AssetManager.as
+++ b/starling/src/starling/utils/AssetManager.as
@@ -602,7 +602,7 @@ package starling.utils
         public function loadQueue(onProgress:Function):void
         {
             if (onProgress == null)
-                throw new ArgumentError("Argument 'onProgress' must not be null");
+                throw new ArgumentError(outputName + " Argument 'onProgress' must not be null");
 
             if (_queue.length == 0)
             {
@@ -613,7 +613,7 @@ package starling.utils
             _starling = Starling.current;
             
             if (_starling == null || _starling.context == null)
-                throw new Error("The Starling instance needs to be ready before assets can be loaded.");
+                throw new Error(outputName + " The Starling instance needs to be ready before assets can be loaded.");
 
             const PROGRESS_PART_ASSETS:Number = 0.9;
             const PROGRESS_PART_XMLS:Number = 1.0 - PROGRESS_PART_ASSETS;
@@ -741,7 +741,7 @@ package starling.utils
                     else log("Cannot create bitmap font: texture '" + name + "' is missing.");
                 }
                 else
-                    throw new Error("XML contents not recognized: " + rootNode);
+                    throw new Error(outputName + " XML contents not recognized: " + rootNode);
 
                 onProgress(PROGRESS_PART_ASSETS + PROGRESS_PART_XMLS * xmlProgress);
                 setTimeout(processXml, 1, index + 1);
@@ -837,7 +837,7 @@ package starling.utils
                         {
                             try
                             {
-                                if (asset == null) throw new Error("Reload failed");
+                                if (asset == null) throw new Error(outputName + " Reload failed");
                                 texture.root.uploadBitmap(asset as Bitmap);
                                 asset.bitmapData.dispose();
                             }
@@ -874,7 +874,7 @@ package starling.utils
                             {
                                 try
                                 {
-                                    if (asset == null) throw new Error("Reload failed");
+                                    if (asset == null) throw new Error(outputName + " Reload failed");
                                     texture.root.uploadAtfData(asset as ByteArray, 0, false);
                                     asset.clear();
                                 }
@@ -1122,12 +1122,14 @@ package starling.utils
                 name = getBasenameFromUrl(name);
 
                 if (name) return name;
-                else throw new ArgumentError("Could not extract name from String '" + rawAsset + "'");
+                else throw new ArgumentError(outputName + " Could not extract name from String '" +
+				                             rawAsset + "'");
             }
             else
             {
                 name = getQualifiedClassName(rawAsset);
-                throw new ArgumentError("Cannot extract names for objects of type '" + name + "'");
+                throw new ArgumentError(outputName + " Cannot extract names for objects of type '" +
+                                        name + "'");
             }
         }
 
@@ -1147,9 +1149,9 @@ package starling.utils
          *  default, it traces 'message' to the console. */
         protected function log(message:String):void
         {
-            if (_verbose) trace("[AssetManager]", message);
+            if (_verbose) trace(outputName, message);
         }
-        
+
         private function byteArrayStartsWith(bytes:ByteArray, char:String):Boolean
         {
             var start:int = 0;
@@ -1300,5 +1302,7 @@ package starling.utils
          *  More connections can reduce loading times, but require more memory. @default 3. */
         public function get numConnections():int { return _numConnections; }
         public function set numConnections(value:int):void { _numConnections = value; }
+
+        private static function get outputName():String { return "[AssetManager]"; }
     }
 }


### PR DESCRIPTION
E.g. "[DisplayObject] Invalid horizontal alignment: lfet"

This is useful when debugging in an environment or situation where we don't have access to the line number or call stack, such as when the error is caught by a handler or logged to a file:

    try {
        var texture:Texture = assetManager.getTexture("texture");
        var image:Image = new Image(texture);
        image.alignPivot("lfet", "top");
        addChild(image);
    } catch (error:Error) {
        Alert.show(error.message, "Error!"); //we'll see the call stack, but not what 
    }

This isn't the best example, but the point is that sometimes you end up with an error message and it's not immediately obvious which class it came from. 

So far I've implemented this for Juggler, Tween, Starling, Button, DisplayObject, AssetManager. If you like the change, I can continue applying it in the remaining classes.

A possible enhancement I just thought of, in case we're concerned about potentially displaying class names to users in a production environment:

    private static function get outputName():String { 
        return (Starling.current.includeClassNamesInErrors) ? "[DisplayObject] " : "";
    }