### PR TITLE
Employing the `numSides` parameter for elliptical gen methods

### DIFF
--- a/starling/src/starling/geom/Polygon.as
+++ b/starling/src/starling/geom/Polygon.as
@@ -283,15 +283,15 @@ package starling.geom
         // factory methods
 
         /** Creates an ellipse with optimized implementations of triangulation, hitTest, etc. */
-        public static function createEllipse(x:Number, y:Number, radiusX:Number, radiusY:Number):Polygon
+        public static function createEllipse(x:Number, y:Number, radiusX:Number, radiusY:Number, numSides:int = -1):Polygon
         {
-            return new Ellipse(x, y, radiusX, radiusY);
+            return new Ellipse(x, y, radiusX, radiusY, numSides);
         }
 
         /** Creates a circle with optimized implementations of triangulation, hitTest, etc. */
-        public static function createCircle(x:Number, y:Number, radius:Number):Polygon
+        public static function createCircle(x:Number, y:Number, radius:Number, numSides:int = -1):Polygon
         {
-            return new Ellipse(x, y, radius, radius);
+            return new Ellipse(x, y, radius, radius, numSides);
         }
 
         /** Creates a rectangle with optimized implementations of triangulation, hitTest, etc. */


### PR DESCRIPTION
The useful parameter of `numSides` in the constructor of the internal class of `Ellipse` is implemented and available; why not allow the users to benefit the advantages of the parameter?!
As the class provides a resolution-independent concept, one may need to have more control on the sides' count, e.g. where the shape may be scaled in a way the imperfection of the to-be elliptical curve is undesirable, and the issue could've been solved easily, if there were more sides on the shape!