### PR TITLE
Introducing the Star polygon

### DIFF
--- a/starling/src/starling/display/Canvas.as
+++ b/starling/src/starling/display/Canvas.as
@@ -70,6 +70,12 @@ package starling.display
             appendPolygon(Polygon.createEllipse(x + radiusX, y + radiusY, radiusX, radiusY));
         }
 
+        /** Draws an n-pointed star. */
+        public function drawStar(x:Number, y:Number, radius1:Number, radius2:Number, numPoints:uint, angleOffset:Number = 0):void
+        {
+            appendPolygon(Polygon.createStar(x, y, radius1, radius2, numPoints, angleOffset));
+        }
+
         /** Draws a rectangle. */
         public function drawRectangle(x:Number, y:Number, width:Number, height:Number):void
         {

--- a/starling/src/starling/display/DisplayObject.as
+++ b/starling/src/starling/display/DisplayObject.as
@@ -153,6 +153,7 @@ package starling.display
         /** @private */ internal var _hasVisibleArea:Boolean;
         /** @private */ internal var _filter:FragmentFilter;
         /** @private */ internal var _mask:DisplayObject;
+        /** @private */ internal var _isMaskInverted:Boolean = false;
 
         // helper objects
 
@@ -1167,6 +1168,10 @@ package starling.display
                 setRequiresRedraw();
             }
         }
+        
+        /** Indicates if the masked region of this object is set to be inverted.*/
+        public function get isMaskInverted():Boolean { return _isMaskInverted; }
+        public function set isMaskInverted(value:Boolean):void { _isMaskInverted = value; }
 
         /** The display object container that contains this display object. */
         public function get parent():DisplayObjectContainer { return _parent; }

--- a/starling/src/starling/display/DisplayObjectContainer.as
+++ b/starling/src/starling/display/DisplayObjectContainer.as
@@ -380,20 +380,21 @@ package starling.display
                     }
                     else
                     {
-                        var pushToken:BatchToken  = cacheEnabled ? child._pushToken : null;
-                        var popToken:BatchToken   = cacheEnabled ? child._popToken  : null;
-                        var filter:FragmentFilter = child._filter;
-                        var mask:DisplayObject    = child._mask;
+                        var pushToken:BatchToken   = cacheEnabled ? child._pushToken : null;
+                        var popToken:BatchToken    = cacheEnabled ? child._popToken  : null;
+                        var filter:FragmentFilter  = child._filter;
+                        var mask:DisplayObject     = child._mask;
+                        var isMaskInverted:Boolean = child._isMaskInverted;
 
                         painter.fillToken(pushToken);
                         painter.setStateTo(child.transformationMatrix, child.alpha, child.blendMode);
 
-                        if (mask) painter.drawMask(mask, child);
+                        if (mask) painter.drawMask(mask, isMaskInverted, child);
 
                         if (filter) filter.render(painter);
                         else        child.render(painter);
 
-                        if (mask) painter.eraseMask(mask, child);
+                        if (mask) painter.eraseMask(mask, isMaskInverted, child);
 
                         painter.fillToken(popToken);
                     }

--- a/starling/src/starling/rendering/Painter.as
+++ b/starling/src/starling/rendering/Painter.as
@@ -353,79 +353,139 @@ package starling.rendering
 
         // masks
 
-        /** Draws a display object into the stencil buffer, incrementing the buffer on each
-         *  used pixel. The stencil reference value is incremented as well; thus, any subsequent
-         *  stencil tests outside of this area will fail.
-         *
-         *  <p>If 'mask' is part of the display list, it will be drawn at its conventional stage
-         *  coordinates. Otherwise, it will be drawn with the current modelview matrix.</p>
-         *
-         *  <p>As an optimization, this method might update the clipping rectangle of the render
-         *  state instead of utilizing the stencil buffer. This is possible when the mask object
-         *  is of type <code>starling.display.Quad</code> and is aligned parallel to the stage
-         *  axes.</p>
-         *
-         *  <p>Note that masking breaks the render cache; the masked object must be redrawn anew
-         *  in the next frame. If you pass <code>maskee</code>, the method will automatically
-         *  call <code>excludeFromCache(maskee)</code> for you.</p>
-         */
-        public function drawMask(mask:DisplayObject, maskee:DisplayObject=null):void
-        {
-            if (_context == null) return;
-
-            finishMeshBatch();
-
-            if (isRectangularMask(mask, maskee, sMatrix))
-            {
-                mask.getBounds(mask, sClipRect);
-                RectangleUtil.getBounds(sClipRect, sMatrix, sClipRect);
-                pushClipRect(sClipRect);
-            }
-            else
-            {
-                _context.setStencilActions(Context3DTriangleFace.FRONT_AND_BACK,
-                    Context3DCompareMode.EQUAL, Context3DStencilAction.INCREMENT_SATURATE);
-
-                renderMask(mask);
-                stencilReferenceValue++;
-
-                _context.setStencilActions(Context3DTriangleFace.FRONT_AND_BACK,
-                    Context3DCompareMode.EQUAL, Context3DStencilAction.KEEP);
-            }
-
-            excludeFromCache(maskee);
-        }
-
-        /** Draws a display object into the stencil buffer, decrementing the
-         *  buffer on each used pixel. This effectively erases the object from the stencil buffer,
-         *  restoring the previous state. The stencil reference value will be decremented.
-         *
-         *  <p>Note: if the mask object meets the requirements of using the clipping rectangle,
-         *  it will be assumed that this erase operation undoes the clipping rectangle change
-         *  caused by the corresponding <code>drawMask()</code> call.</p>
-         */
-        public function eraseMask(mask:DisplayObject, maskee:DisplayObject=null):void
-        {
-            if (_context == null) return;
-
-            finishMeshBatch();
-
-            if (isRectangularMask(mask, maskee, sMatrix))
-            {
-                popClipRect();
-            }
-            else
-            {
-                _context.setStencilActions(Context3DTriangleFace.FRONT_AND_BACK,
-                    Context3DCompareMode.EQUAL, Context3DStencilAction.DECREMENT_SATURATE);
-
-                renderMask(mask);
-                stencilReferenceValue--;
-
-                _context.setStencilActions(Context3DTriangleFace.FRONT_AND_BACK,
-                    Context3DCompareMode.EQUAL, Context3DStencilAction.KEEP);
-            }
-        }
+        /** Draws a display object into the stencil buffer only; increments or decrements the 
+		 *  entry value corresponding to the pixel of the shape in the stencil buffer, for the
+		 *  normal or inverted mask modes, respectively. Effectively, the stencil buffer 
+		 *  modification is to mark only the appropriate pixel coordinates where the 'maskee' 
+		 *  object is to be rendered.<br>
+		 *  The stencil reference value will be incremented in the normal mask mode only.
+		 *
+		 *  <p>If the 'mask' is part of the display list, it will be drawn at its conventional 
+		 *  stage coordinates. Otherwise, it will be drawn with the current modelview matrix.</p>
+		 *
+		 *  <p>As an optimization, this method might update the clipping rectangle of the render
+		 *  state instead of utilizing the stencil buffer. This is possible when the mask object
+		 *  is of type <code>starling.display.Quad</code> and is aligned parallel to the stage
+		 *  axes.</p>
+		 *
+		 *  <p>Note that masking breaks the render cache; the masked object must be redrawn anew
+		 *  in the next frame. If you pass <code>maskee</code>, the method will automatically
+		 *  call <code>excludeFromCache(maskee)</code> for you.</p>
+		 */
+		public function drawMask(mask:DisplayObject, isMaskInverted:Boolean=false, maskee:DisplayObject=null):void
+		{
+			if (_context == null) return;
+			
+			finishMeshBatch();
+			
+			if (isRectangularMask(mask, maskee, sMatrix))
+			{
+				mask.getBounds(mask, sClipRect);
+				RectangleUtil.getBounds(sClipRect, sMatrix, sClipRect);
+				pushClipRect(sClipRect);
+			}
+			else
+			{
+				// The mask should 'never' be written to the destination color buffer
+				_context.setDepthTest(false, Context3DCompareMode.NEVER);
+				
+				// Since the depth test for the mask object always fails, the stencil action
+				// specified throught the 4th argument of the 'setStencilActions()' method is
+				// the only action that will be carried out during the stencil test.
+				// The ineffectual but yet valid value of 'Context3DStencilAction.KEEP' is passed
+				// as the 3rd argument of the method, only to reach the next argument.
+				if (isMaskInverted)
+				{
+					_context.setStencilActions(Context3DTriangleFace.FRONT_AND_BACK,
+						Context3DCompareMode.ALWAYS,
+						Context3DStencilAction.KEEP,
+						Context3DStencilAction.DECREMENT_SATURATE
+					);
+					
+					renderMask(mask);
+				}
+				else
+				{
+					_context.setStencilActions(Context3DTriangleFace.FRONT_AND_BACK,
+						Context3DCompareMode.EQUAL,
+						Context3DStencilAction.KEEP,
+						Context3DStencilAction.INCREMENT_SATURATE
+					);
+					
+					renderMask(mask);
+					stencilReferenceValue++;
+				}
+				
+				// Reset the depth test
+				_context.setDepthTest(false, Context3DCompareMode.ALWAYS);
+				
+				// Reset all the stencil actions back to the default value of 'Context3DStencilAction.KEEP'
+				_context.setStencilActions(Context3DTriangleFace.FRONT_AND_BACK, Context3DCompareMode.EQUAL);
+			}
+			
+			excludeFromCache(maskee);
+		}
+		
+		/** Draws a display object into the stencil buffer only; increments or decrements the 
+		 *  entry value corresponding to the pixel of the shape in the stencil buffer, for the
+		 *  inverted or normal mask modes, respectively. Effectively, The stencil buffer 
+		 *  modification is to erase the object shape from the stencil buffer, restoring the 
+		 *  previous state.<br>
+		 *  The stencil reference value will be decremented in the normal mask mode only.
+		 *
+		 *  <p>Note: if the mask object meets the requirements of using the clipping rectangle,
+		 *  it will be assumed that this erase operation undoes the clipping rectangle change
+		 *  caused by the corresponding <code>drawMask()</code> call.</p>
+		 */
+		public function eraseMask(mask:DisplayObject, isMaskInverted:Boolean=false, maskee:DisplayObject=null):void
+		{
+			if (_context == null) return;
+			
+			finishMeshBatch();
+			
+			if (isRectangularMask(mask, maskee, sMatrix))
+			{
+				popClipRect();
+			}
+			else
+			{
+				// The mask should 'never' be written to the destination color buffer
+				_context.setDepthTest(false, Context3DCompareMode.NEVER);
+				
+				// Since the depth test for the mask object always fails, the stencil action
+				// specified throught the 4th argument of the 'setStencilActions()' method is
+				// the only action that will be carried out during the stencil test.
+				// The ineffectual but yet valid value of 'Context3DStencilAction.KEEP' is passed
+				// as the 3rd argument of the method, only to reach the next argument.
+				if (isMaskInverted)
+				{
+					_context.setStencilActions(Context3DTriangleFace.FRONT_AND_BACK,
+						Context3DCompareMode.ALWAYS,
+						Context3DStencilAction.KEEP,
+						Context3DStencilAction.INCREMENT_SATURATE
+					);
+					
+					renderMask(mask);
+				}
+				else
+				{
+					_context.setStencilActions(Context3DTriangleFace.FRONT_AND_BACK,
+						Context3DCompareMode.EQUAL,
+						Context3DStencilAction.KEEP,
+						Context3DStencilAction.DECREMENT_SATURATE
+					);
+					
+					renderMask(mask);
+					stencilReferenceValue--;
+				}
+				
+				// Reset the depth test
+				_context.setDepthTest(false, Context3DCompareMode.ALWAYS);
+				
+				// Reset all the stencil actions back to the default value of 'Context3DStencilAction.KEEP'
+				_context.setStencilActions(Context3DTriangleFace.FRONT_AND_BACK, Context3DCompareMode.EQUAL);
+			}
+		}
 
         private function renderMask(mask:DisplayObject):void
         {

--- a/starling/src/starling/rendering/Painter.as
+++ b/starling/src/starling/rendering/Painter.as
@@ -627,7 +627,7 @@ package starling.rendering
             _context.setDepthTest(false, Context3DCompareMode.ALWAYS);
 
             // reset everything else
-            stencilReferenceValue = 0;
+            stencilReferenceValue = 127;
             _clipRectStack.length = 0;
             _drawCount = 0;
             _stateStackPos = -1;
@@ -729,7 +729,7 @@ package starling.rendering
         public function clear(rgb:uint=0, alpha:Number=0.0):void
         {
             applyRenderTarget();
-            stencilReferenceValue = 0;
+            stencilReferenceValue = 127;
             RenderUtil.clear(rgb, alpha);
         }
 

--- a/starling/src/starling/textures/RenderTexture.as
+++ b/starling/src/starling/textures/RenderTexture.as
@@ -196,6 +196,7 @@ package starling.textures
             var wasCacheEnabled:Boolean = painter.cacheEnabled;
             var filter:FragmentFilter = object.filter;
             var mask:DisplayObject = object.mask;
+            var isMaskInverted:Boolean = object.isMaskInverted;
 
             painter.cacheEnabled = false;
             painter.pushState();
@@ -208,12 +209,12 @@ package starling.textures
             if (matrix) state.transformModelviewMatrix(matrix);
             else        state.transformModelviewMatrix(object.transformationMatrix);
 
-            if (mask)   painter.drawMask(mask);
+            if (mask)   painter.drawMask(mask, isMaskInverted);
 
             if (filter) filter.render(painter);
             else        object.render(painter);
 
-            if (mask)   painter.eraseMask(mask);
+            if (mask)   painter.eraseMask(mask, isMaskInverted);
 
             painter.popState();
             painter.cacheEnabled = wasCacheEnabled;

--- a/starling/src/starling/utils/RenderUtil.as
+++ b/starling/src/starling/utils/RenderUtil.as
@@ -44,7 +44,7 @@ package starling.utils
                     Color.getBlue(rgb)  / 255.0,
                     alpha,
                     1.0, // depth
-					127  // stencil
+		    127  // stencil
              );
         }
 

--- a/starling/src/starling/utils/RenderUtil.as
+++ b/starling/src/starling/utils/RenderUtil.as
@@ -42,7 +42,10 @@ package starling.utils
                     Color.getRed(rgb)   / 255.0,
                     Color.getGreen(rgb) / 255.0,
                     Color.getBlue(rgb)  / 255.0,
-                    alpha);
+                    alpha,
+                    1.0, // depth
+					127  // stencil
+             );
         }
 
         /** Returns the flags that are required for AGAL texture lookup,


### PR DESCRIPTION
Using the new `Star` class, you can create custom n-pointed star shapes with _really_ optimized triangulation and `hitTest()` functionalities.
The _Starling_ framework is no longer imaginable without the polygonal _star_ generation routine _!!_ :joy: (joking)