### PR TITLE
Check context in Painter before disposing

### DIFF
--- a/starling/src/starling/rendering/Painter.as
+++ b/starling/src/starling/rendering/Painter.as
@@ -166,7 +166,8 @@ package starling.rendering
 
             if (!_shareContext)
             {
-                _context.dispose(false);
+                if (_context)
+                    _context.dispose(false);
                 sSharedData = new Dictionary();
             }
         }

--- a/starling/src/starling/utils/RenderUtil.as
+++ b/starling/src/starling/utils/RenderUtil.as
@@ -232,7 +232,11 @@ package starling.utils
             {
                 currentProfile = profiles.shift();
 
-                try { execute(stage3D.requestContext3D, renderMode, currentProfile); }
+                try
+                {
+                    SystemUtil.executeWhenApplicationIsActive(
+                        stage3D.requestContext3D, renderMode, currentProfile);
+                }
                 catch (error:Error)
                 {
                     if (profiles.length != 0) setTimeout(requestNextProfile, 1);


### PR DESCRIPTION
Have a problem with Starling's initialisation on iOS.
It fails with error 3702 on context initialisation if application was in background.
To recreate this error you need to move application into background when Starling is waiting for context creation.
It can be done many different ways, but the simplest is by double pressing home button.
After that a little waiting is needed, and select the application again.
It's like in one of the forum's posts:
https://forum.starling-framework.org/topic/recover-from-context3d-not-available-when-starting-ios-app-in-the-background
Was this already solved before?

For now I do workaround, by catching ERROR and recreating Starling instance.
And I tried to dispose old instance to ensure that it will not catch stage events.
But failed on Painter's dispose method, because there was no context.