### PR TITLE
Starling: calls setRequiresRedraw() on Event.ACTIVATE because it is sometimes required with AIR on Windows

### DIFF
--- a/starling/src/starling/core/Starling.as
+++ b/starling/src/starling/core/Starling.as
@@ -300,6 +300,7 @@ package starling.core
             stage.addEventListener(KeyboardEvent.KEY_UP, onKey, false, 0, true);
             stage.addEventListener(Event.RESIZE, onResize, false, 0, true);
             stage.addEventListener(Event.MOUSE_LEAVE, onMouseLeave, false, 0, true);
+            stage.addEventListener(Event.ACTIVATE, onActivate, false, 0, true);
 
             stage3D.addEventListener(Event.CONTEXT3D_CREATE, onContextCreated, false, 10, true);
             stage3D.addEventListener(ErrorEvent.ERROR, onStage3DError, false, 10, true);
@@ -620,6 +621,14 @@ package starling.core
             }
 
             updateNativeOverlay();
+        }
+
+        private function onActivate(event:Event):void
+        {
+            // on Windows with Context3DProfile.BASELINE_CONSTRAINED and
+            // skipUnchangedFrames, if Starling is minimized and isn't stopped 
+            // on deactivate, force redraw is required when app is restored.
+            setTimeout(setRequiresRedraw, 100);
         }
         
         private function onKey(event:KeyboardEvent):void


### PR DESCRIPTION
If a desktop AIR app is minimized, it may render with a blank white screen when the window is restored later. Moving the mouse around may cause Starling to start rendering again if the interaction triggers anything that might require a redraw.

There are a few requirements to reproduce this issue:

1) **Windows** only. The issue does not reproduce on macOS.

2) Must be using **Context3DProfile.BASELINE_CONSTRAINED**.

3) **skipUnchangedFrames** must be true.

4) Must **NOT** stop Starling on Event.DEACTIVATE and restart it on Event.ACTIVATE.

To fix this issue, I added a listener for Event.ACTIVATE inside the Starling class. In the listener, I call setRequiresRedraw() after a 100 ms delay. Calling it immediately did not work for me. This is the same workaround that already exists in start() (the comment says it may be required on Android), but it works even if you want to allow a desktop app to render while in the background.

I did not remove the existing workaround in start(), but I think it may be redundant now.