### PR TITLE
Fix RenderTexture dispose() texture

### DIFF
--- a/starling/src/starling/textures/RenderTexture.as
+++ b/starling/src/starling/textures/RenderTexture.as
@@ -143,7 +143,10 @@ package starling.textures
         /** @inheritDoc */
         public override function dispose():void
         {
-            _activeTexture.dispose();
+            // if _ownsParent is true, _activeTexture will be disposed by the super.dispose() call
+            if (!_ownsParent) {
+                _activeTexture.dispose();
+            }
             
             if (isDoubleBuffered)
             {


### PR DESCRIPTION
_activeTexture was being disposed twice once in RenderTexture and once in SubTexture. Only dispose it in RenderTexture if SubTexture isn't going to dispose it.