### PR TITLE
Update AtfTextureFactory.as to execute custom TextureOptions.onReady

### DIFF
--- a/starling/src/starling/assets/AtfTextureFactory.as
+++ b/starling/src/starling/assets/AtfTextureFactory.as
@@ -28,8 +28,10 @@ package starling.assets
 
             function createTexture():void
             {
+                var onReady:Function = reference.textureOptions.onReady as Function;
                 reference.textureOptions.onReady = function():void
                 {
+                    execute(onReady, texture);
                     onComplete(reference.name, texture);
                 };
 

--- a/starling/src/starling/assets/AtfTextureFactory.as
+++ b/starling/src/starling/assets/AtfTextureFactory.as
@@ -4,6 +4,7 @@ package starling.assets
 
     import starling.textures.AtfData;
     import starling.textures.Texture;
+    import starling.utils.execute;
 
     /** This AssetFactory creates texture assets from ATF files. */
     public class AtfTextureFactory extends AssetFactory


### PR DESCRIPTION
A reference to the original TextureOptions.onReady is now stored and executed by the overwriting onReady closure.