### PR TITLE
added small optimization to Polygon 'contains' method

### DIFF
--- a/starling/src/starling/geom/Polygon.as
+++ b/starling/src/starling/geom/Polygon.as
@@ -131,6 +131,7 @@ package starling.geom
             // Algorithm & implementation thankfully taken from:
             // -> http://alienryderflex.com/polygon/
 
+            var numVertices:int = this.numVertices;
             var i:int, j:int = numVertices - 1;
             var oddNodes:uint = 0;
 


### PR DESCRIPTION
Hi @PrimaryFeather!

Adobe Scout reported me that quite a lot of time was spent in the `numVertices` accessor while using the `contains` method.

What do you think about this small optimization? It seems to be used in few other similar methods too...

Best,
Aurélien