### PR TITLE
Optimize removeChild

### DIFF
--- a/starling/src/starling/display/DisplayObjectContainer.as
+++ b/starling/src/starling/display/DisplayObjectContainer.as
@@ -175,7 +175,10 @@ package starling.display
                 }
                 
                 child.setParent(null);
+				if (index > _children.length-1 || _children[index] != child)
+				{
                 index = _children.indexOf(child); // index might have changed by event handler
+				}
                 if (index >= 0) _children.removeAt(index);
                 if (dispose) child.dispose();
                 


### PR DESCRIPTION
Prevent RemoveChild needlessly doing indexOf.
This was causing O(n log n) behavior in the case of removing all children.
Fix short black screen at the end of Starling demo benchmark for large amount of Images.
