### PR TITLE
Json Factory: Added support for root json array

### DIFF
--- a/starling/src/starling/assets/JsonFactory.as
+++ b/starling/src/starling/assets/JsonFactory.as
@@ -18,7 +18,8 @@ package starling.assets
         override public function canHandle(reference:AssetReference):Boolean
         {
             return super.canHandle(reference) || (reference.data is ByteArray &&
-                ByteArrayUtil.startsWithString(reference.data as ByteArray, "{"));
+                (ByteArrayUtil.startsWithString(reference.data as ByteArray, "{")
+                || ByteArrayUtil.startsWithString(reference.data as ByteArray, "[")));
         }
 
         /** @inheritDoc */


### PR DESCRIPTION
Hi Daniel,

I just noticed that the `Json Factory` doesn't support root JSON array. 

According to the format definition root arrays are valid. So after this changes embed files starting with `[` will be considered as JSON and will be parsed accordingly.

I tested it and everything works as expected.

See you,
Aurélien