### PR TITLE
Juggler: Fixed pooled tweens & delayed calls not properly released in pool when purging the juggler (V2)

### DIFF
--- a/starling/src/starling/events/Event.as
+++ b/starling/src/starling/events/Event.as
@@ -17,22 +17,22 @@ package starling.events
 
     use namespace starling_internal;
 
-    /** Event objects are passed as parameters to event listeners when an event occurs.  
-     *  This is Starling's version of the Flash Event class. 
+    /** Event objects are passed as parameters to event listeners when an event occurs.
+     *  This is Starling's version of the Flash Event class.
      *
-     *  <p>EventDispatchers create instances of this class and send them to registered listeners. 
-     *  An event object contains information that characterizes an event, most importantly the 
-     *  event type and if the event bubbles. The target of an event is the object that 
+     *  <p>EventDispatchers create instances of this class and send them to registered listeners.
+     *  An event object contains information that characterizes an event, most importantly the
+     *  event type and if the event bubbles. The target of an event is the object that
      *  dispatched it.</p>
-     * 
-     *  <p>For some event types, this information is sufficient; other events may need additional 
-     *  information to be carried to the listener. In that case, you can subclass "Event" and add 
-     *  properties with all the information you require. The "EnterFrameEvent" is an example for 
+     *
+     *  <p>For some event types, this information is sufficient; other events may need additional
+     *  information to be carried to the listener. In that case, you can subclass "Event" and add
+     *  properties with all the information you require. The "EnterFrameEvent" is an example for
      *  this practice; it adds a property about the time that has passed since the last frame.</p>
-     * 
-     *  <p>Furthermore, the event class contains methods that can stop the event from being 
+     *
+     *  <p>Furthermore, the event class contains methods that can stop the event from being
      *  processed by other listeners - either completely or at the next bubble stage.</p>
-     * 
+     *
      *  @see EventDispatcher
      */
     public class Event
@@ -64,6 +64,8 @@ package starling.events
         public static const ROOT_CREATED:String = "rootCreated";
         /** Event type for an animated object that requests to be removed from the juggler. */
         public static const REMOVE_FROM_JUGGLER:String = "removeFromJuggler";
+        /** Event type for an animated object that is removed from its juggler. */
+        public static const REMOVED_FROM_JUGGLER:String = "removedFromJuggler";
         /** Event type that is dispatched by the AssetManager after a context loss. */
         public static const TEXTURES_RESTORED:String = "texturesRestored";
         /** Event type that is dispatched by the AssetManager when a file/url cannot be loaded. */
@@ -93,9 +95,9 @@ package starling.events
         public static const READY:String = "ready";
         /** An event type to be utilized in custom events. Not used by Starling right now. */
         public static const UPDATE:String = "update";
-        
+
         private static var sEventPool:Vector.<Event> = new <Event>[];
-        
+
         private var _target:EventDispatcher;
         private var _currentTarget:EventDispatcher;
         private var _type:String;
@@ -103,7 +105,7 @@ package starling.events
         private var _stopsPropagation:Boolean;
         private var _stopsImmediatePropagation:Boolean;
         private var _data:Object;
-        
+
         /** Creates an event object that can be passed to listeners. */
         public function Event(type:String, bubbles:Boolean=false, data:Object=null)
         {
@@ -111,74 +113,74 @@ package starling.events
             _bubbles = bubbles;
             _data = data;
         }
-        
+
         /** Prevents listeners at the next bubble stage from receiving the event. */
         public function stopPropagation():void
         {
             _stopsPropagation = true;
         }
-        
+
         /** Prevents any other listeners from receiving the event. */
         public function stopImmediatePropagation():void
         {
             _stopsPropagation = _stopsImmediatePropagation = true;
         }
-        
+
         /** Returns a description of the event, containing type and bubble information. */
         public function toString():String
         {
             return StringUtil.format("[{0} type=\"{1}\" bubbles={2}]",
                 getQualifiedClassName(this).split("::").pop(), _type, _bubbles);
         }
-        
+
         /** Indicates if event will bubble. */
         public function get bubbles():Boolean { return _bubbles; }
-        
+
         /** The object that dispatched the event. */
         public function get target():EventDispatcher { return _target; }
-        
+
         /** The object the event is currently bubbling at. */
         public function get currentTarget():EventDispatcher { return _currentTarget; }
-        
+
         /** A string that identifies the event. */
         public function get type():String { return _type; }
-        
+
         /** Arbitrary data that is attached to the event. */
         public function get data():Object { return _data; }
-        
+
         // properties for internal use
-        
+
         /** @private */
         internal function setTarget(value:EventDispatcher):void { _target = value; }
-        
+
         /** @private */
         internal function setCurrentTarget(value:EventDispatcher):void { _currentTarget = value; }
-        
+
         /** @private */
         internal function setData(value:Object):void { _data = value; }
-        
+
         /** @private */
         internal function get stopsPropagation():Boolean { return _stopsPropagation; }
-        
+
         /** @private */
         internal function get stopsImmediatePropagation():Boolean { return _stopsImmediatePropagation; }
-        
+
         // event pooling
-        
+
         /** @private */
         starling_internal static function fromPool(type:String, bubbles:Boolean=false, data:Object=null):Event
         {
             if (sEventPool.length) return sEventPool.pop().reset(type, bubbles, data);
             else return new Event(type, bubbles, data);
         }
-        
+
         /** @private */
         starling_internal static function toPool(event:Event):void
         {
             event._data = event._target = event._currentTarget = null;
             sEventPool[sEventPool.length] = event; // avoiding 'push'
         }
-        
+
         /** @private */
         starling_internal function reset(type:String, bubbles:Boolean=false, data:Object=null):Event
         {


### PR DESCRIPTION
Hey Daniel,

Here is a second implementation following your comment on https://github.com/Gamua/Starling-Framework/pull/1101. 

It seems to be working fine on my side but I didn't run the unit tests suite. Could you double check?

See you!
Aurélien

*Sorry for the white spaces cleaning 😬