### PR TITLE
Starling: Fix ambiguous reference compiler warning

### DIFF
--- a/starling/src/starling/core/Starling.as
+++ b/starling/src/starling/core/Starling.as
@@ -1222,7 +1222,7 @@ package starling.core
 
         /** The default texture smoothing value of 'Starling.current', or 'bilinear'.
          *  @default "bilinear" */
-        public static function get defaultTextureSmoothing():String
+        public static function get currentDefaultTextureSmoothing():String
         {
             return sCurrent ? sCurrent._defaultTextureSmoothing : TextureSmoothing.BILINEAR;
         }

--- a/starling/src/starling/filters/FragmentFilter.as
+++ b/starling/src/starling/filters/FragmentFilter.as
@@ -119,7 +119,7 @@ package starling.filters
         {
             _resolution = 1.0;
             _textureFormat = Context3DTextureFormat.BGRA;
-            _textureSmoothing = Starling.defaultTextureSmoothing;
+            _textureSmoothing = Starling.currentDefaultTextureSmoothing;
 
             // Handle lost context (using conventional Flash event for weak listener support)
             Starling.current.stage3D.addEventListener(Event.CONTEXT3D_CREATE,

--- a/starling/src/starling/rendering/FilterEffect.as
+++ b/starling/src/starling/rendering/FilterEffect.as
@@ -48,7 +48,7 @@ package starling.rendering
         /** Creates a new FilterEffect instance. */
         public function FilterEffect()
         {
-            _textureSmoothing = Starling.defaultTextureSmoothing;
+            _textureSmoothing = Starling.currentDefaultTextureSmoothing;
         }
 
         /** Override this method if the effect requires a different program depending on the

--- a/starling/src/starling/styles/MeshStyle.as
+++ b/starling/src/starling/styles/MeshStyle.as
@@ -111,7 +111,7 @@ package starling.styles
          *  Subclasses must provide a constructor that can be called without any arguments. */
         public function MeshStyle()
         {
-            _textureSmoothing = Starling.defaultTextureSmoothing;
+            _textureSmoothing = Starling.currentDefaultTextureSmoothing;
             _type = Object(this).constructor as Class;
         }
 


### PR DESCRIPTION
This PR fixes the following compiler warning:

![ambiguous reference warning](https://user-images.githubusercontent.com/1126990/210352877-b13c414b-2a07-4140-a233-152b41b95ced.png)

@PrimaryFeather Here is my renaming proposal, please let me know if you think that another name would be better.