### PR TITLE
fix for BlendMode.isRegistered function error when calling it early

### DIFF
--- a/starling/src/starling/display/BlendMode.as
+++ b/starling/src/starling/display/BlendMode.as
@@ -126,6 +126,7 @@ package starling.display
         /** Returns true if a blend mode with the given name is available. */
         public static function isRegistered(modeName:String):Boolean
         {
+			if (sBlendModes == null) registerDefaults();
             return modeName in sBlendModes;
         }
 


### PR DESCRIPTION
if you call this when your main Starling class is created or added to stage, it results in an error because sBlendModes is null. Other BlendMode methods check for this and call registerDefaults() if needed so I did the same