### PR TITLE
Starling: Small rendering events improvements

### DIFF
--- a/starling/src/starling/core/Starling.as
+++ b/starling/src/starling/core/Starling.as
@@ -429,7 +429,8 @@ package starling.core
          *
          *  <p>This method also dispatches an <code>Event.RENDER</code>-event on the Starling
          *  instance. That's the last opportunity to make changes before the display list is
-         *  rendered.</p> */
+         *  rendered. When the rendering is completed, this method dispatches an
+         *  <code>Event.RENDER_COMPLETE</code>-event on the Starling instance too.</p> */
         public function render():void
         {
             if (!contextValid)
@@ -466,6 +467,8 @@ package starling.core
 
                 if (!shareContext)
                     _painter.present();
+
+                 dispatchEventWith(starling.events.Event.RENDER_COMPLETE);
             }
             else
                 dispatchEventWith(starling.events.Event.SKIP_FRAME);

--- a/starling/src/starling/core/Starling.as
+++ b/starling/src/starling/core/Starling.as
@@ -442,6 +442,10 @@ package starling.core
             var doRedraw:Boolean = _stage.requiresRedraw || mustAlwaysRender;
             if (doRedraw)
             {
+                // setup next frame before the RENDER event to take into account all draw calls
+                // that could happen in reaction of the event.
+                _painter.nextFrame();
+
                 dispatchEventWith(starling.events.Event.RENDER);
 
                 var shareContext:Boolean = _painter.shareContext;
@@ -449,7 +453,6 @@ package starling.core
                 var scaleY:Number = _viewPort.height / _stage.stageHeight;
                 var stageColor:uint = _stage.color;
 
-                _painter.nextFrame();
                 _painter.pixelSize = 1.0 / contentScaleFactor;
                 _painter.state.setProjectionMatrix(
                     _viewPort.x < 0 ? -_viewPort.x / scaleX : 0.0,

--- a/starling/src/starling/events/Event.as
+++ b/starling/src/starling/events/Event.as
@@ -57,6 +57,8 @@ package starling.events
         public static const CONTEXT3D_CREATE:String = "context3DCreate";
         /** Event type that is dispatched by the Starling instance directly before rendering. */
         public static const RENDER:String = "render";
+        /** Event type that is dispatched by the Starling instance after rendering. */
+        public static const RENDER_COMPLETE:String = "renderComplete";
         /** Event type for a frame that is skipped because the display list did not change.
          *  Dispatched instead of the <code>RENDER</code> event. */
         public static const SKIP_FRAME:String = "skipFrame";


### PR DESCRIPTION
Hi @PrimaryFeather !

Here is a small PR to propose an improvement regarding the rendering events.

### Changes

1) The first commit introduces a new event `RENDER_COMPLETE` to indicate when the rendering has been completed.
2) The second commit fixes the stats display to take into account all draw calls that might happen during the reception of the RENDER event.

### Context

I'm using those changes to implement a post processing stack at different stages of rendering (screen, camera, etc.). The first commit let me hide display objects (mark them as not visible) and make them back visible after rendering to let them be taken into account for the touch processing.

The second commit allows me to track all draw calls done during the deferred rendering through render textures.

I'm obviously open to discuss any side effect you might see from those changes.

Best,
Aurélien