### PR TITLE
Display Object Container: Fixed bounds computation when a container has children with no size

### DIFF
--- a/starling/src/starling/display/DisplayObjectContainer.as
+++ b/starling/src/starling/display/DisplayObjectContainer.as
@@ -305,6 +305,7 @@ package starling.display
             }
             else
             {
+                var sizedChildrenCount:uint = 0;
                 var minX:Number = Number.MAX_VALUE, maxX:Number = -Number.MAX_VALUE;
                 var minY:Number = Number.MAX_VALUE, maxY:Number = -Number.MAX_VALUE;
 
@@ -312,13 +313,29 @@ package starling.display
                 {
                     _children[i].getBounds(targetSpace, out);
 
+                    // ignore child with no size
+                    if (out.width == 0 && out.height == 0)
+                        continue;
+
+                    ++sizedChildrenCount;
                     if (minX > out.x)      minX = out.x;
                     if (maxX < out.right)  maxX = out.right;
                     if (minY > out.y)      minY = out.y;
                     if (maxY < out.bottom) maxY = out.bottom;
                 }
 
-                out.setTo(minX, minY, maxX - minX, maxY - minY);
+                // all children have no size
+                if (sizedChildrenCount == 0)
+                {
+                    getTransformationMatrix(targetSpace, sBoundsMatrix);
+                    MatrixUtil.transformCoords(sBoundsMatrix, 0.0, 0.0, sBoundsPoint);
+                    out.setTo(sBoundsPoint.x, sBoundsPoint.y, 0, 0);
+                }
+                // at least one child is sized
+                else
+                {
+                    out.setTo(minX, minY, maxX - minX, maxY - minY);
+                }
             }
             
             return out;


### PR DESCRIPTION
Hey @PrimaryFeather,

I just discovered a surprising issue related to the computation of bounds of display container composed with "non sized" display objects. Those "non sized" display objects contribute to the bounds of the parent but actually shouldn't.

This results with incorrect bounds.

---

Here is a simple code repoducing the issue:

```
var mainSprite:Sprite = new Sprite();
trace("Sprite width: " + mainSprite.bounds.width);

var emptySprite:Sprite = new Sprite();
mainSprite.addChild(emptySprite);
trace("Sprite width: " + mainSprite.bounds.width);

var quad:Quad = new Quad(10, 10);
quad.x = 100;
mainSprite.addChild(quad);
trace("Sprite width: " + mainSprite.bounds.width);
```
The expected width is `10` since only the quad is visible.

---

Output without the fix:
```
Sprite width: 0
Sprite width: 0
Sprite width: 110
```
👉 This is due to the fact that the empty sprite is located at 0 influencing the bounds from 0 to 100 (quad's position) + 10 (quad's size).

Output with the fix:
```
Sprite width: 0
Sprite width: 0
Sprite width: 10
```
