### PR TITLE
Update ConcretePotTexture.as

### DIFF
--- a/starling/src/starling/textures/ConcretePotTexture.as
+++ b/starling/src/starling/textures/ConcretePotTexture.as
@@ -89,6 +89,7 @@ package starling.textures
             {
                 var currentWidth:int  = data.width  >> 1;
                 var currentHeight:int = data.height >> 1;
+                var last_canvas:BitmapData = null;
                 var level:int = 1;
                 var matrix:Matrix = sMatrix;
                 matrix.setTo(0.5, 0.0, 0.0, 0.5, 0.0, 0.0);
@@ -96,12 +97,20 @@ package starling.textures
                 while (currentWidth >= 1 || currentHeight >= 1)
                 {
                     var canvas:BitmapData = new BitmapData(Math.max(1, currentWidth), Math.max(1, currentHeight), true, 0);
-                    canvas.draw(data, matrix, null, null, null, true);
+                    if (level == 1) {
+                     canvas.draw(data, matrix, null, null, null, true);
+                    } else {
+                     canvas.draw(last_canvas, matrix, null, null, null, true);
+                     last_canvas.dispose();
+                    }
+                    last_canvas = canvas;
                     upload(canvas, level++, false); // only level 0 supports async
-                    matrix.scale(0.5, 0.5);
                     currentWidth  = currentWidth  >> 1;
                     currentHeight = currentHeight >> 1;
-                    canvas.dispose();
+                }
+                
+                if (last_canvas != null) {
+                    last_canvas.dispose();
                 }
 
             }

--- a/starling/src/starling/textures/ConcretePotTexture.as
+++ b/starling/src/starling/textures/ConcretePotTexture.as
@@ -90,23 +90,20 @@ package starling.textures
                 var currentWidth:int  = data.width  >> 1;
                 var currentHeight:int = data.height >> 1;
                 var level:int = 1;
-                var canvas:BitmapData = new BitmapData(currentWidth, currentHeight, true, 0);
-                var bounds:Rectangle = sRectangle;
                 var matrix:Matrix = sMatrix;
                 matrix.setTo(0.5, 0.0, 0.0, 0.5, 0.0, 0.0);
 
                 while (currentWidth >= 1 || currentHeight >= 1)
                 {
-                    bounds.setTo(0, 0, currentWidth, currentHeight);
-                    canvas.fillRect(bounds, 0);
+                    var canvas:BitmapData = new BitmapData(Math.max(1, currentWidth), Math.max(1, currentHeight), true, 0);
                     canvas.draw(data, matrix, null, null, null, true);
                     upload(canvas, level++, false); // only level 0 supports async
                     matrix.scale(0.5, 0.5);
                     currentWidth  = currentWidth  >> 1;
                     currentHeight = currentHeight >> 1;
+                    canvas.dispose();
                 }
 
-                canvas.dispose();
             }
 
             if (buffer) buffer.dispose();


### PR DESCRIPTION
When uploading a 2048x2048 texture, all smaller mipmap levels were then uploading as 1024x1024, because that was the only BitmapData size that ever got created in the whole mipmap upload process. I changed it so now the deeper levels upload as BitmapData objects that are sized 512x512, 256x256, etc. Was it correct for me to change this, or am I making a mistake?

Also I am curious, why doesn't Starling support async uploads for mipmaps, is it due to hardware limitations or something else?