### PR TITLE
Add "offset" to earcut use.

### DIFF
--- a/starling/src/starling/geom/Polygon.as
+++ b/starling/src/starling/geom/Polygon.as
@@ -182,7 +182,7 @@ package starling.geom
 
                 var triangleCount:int = indexes.length/3;
                 for (var triIndex:int = 0; triIndex < triangleCount; triIndex++)
-                    indexData.addTriangle(indexes[triIndex*3], indexes[triIndex*3+1], indexes[triIndex*3+2]);
+                    indexData.addTriangle(indexes[triIndex*3]+offset, indexes[triIndex*3+1]+offset, indexes[triIndex*3+2]+offset);
                 return indexData;
             }
 


### PR DESCRIPTION
The new "earcut" code in Polygon.as does not have the "offset" parameter added to the indexes.