### PR TITLE
Force close current path on canvas if endFill is called

### DIFF
--- a/starling/src/starling/display/Canvas.as
+++ b/starling/src/starling/display/Canvas.as
@@ -110,6 +110,16 @@ package starling.display
         /** Resets the color to 'white' and alpha to '1'. */
         public function endFill():void
         {
+            if(_currentPath.length > 0) {
+                const lastX:Number = _currentPath[_currentPath.length - 2];
+                const lastY:Number = _currentPath[_currentPath.length - 1];
+
+                if (lastX != _currentPath[0] && lastY != _currentPath[1])
+                {
+                    lineTo(_currentPath[0], _currentPath[1]);
+                    drawPathIfClosed();
+                }
+            }
             _fillColor = 0xffffff;
             _fillAlpha = 1.0;
         }


### PR DESCRIPTION
Before this code would render nothing
```as
package
{
    import starling.display.Sprite;
    import starling.display.Canvas;

    public class Main extends Sprite
    {
        public function Main()
        {
            var canvas:Canvas = new Canvas();
            canvas.beginFill(0xff0000);
            canvas.moveTo(20, 0);
            canvas.lineTo(130, 0);
            canvas.curveTo(150, 0, 150, 20);
            canvas.lineTo(150, 80);
            canvas.endFill();
            addChild(canvas);
        }
    }
}
```
this doesn't match flash, who force closes the path on endFill(), this PR makes Canvas also do this
<img width="502" height="475" alt="image" src="https://github.com/user-attachments/assets/2715086a-58fb-4f50-ad23-e826164d7073" />

Big thanks to @joshtynjala for noticing this when testing the OpenFL version of #1121  I submitted