### PR TITLE
Canvas: fix exception in endFill() when _currentPath is null

### DIFF
--- a/starling/src/starling/display/Canvas.as
+++ b/starling/src/starling/display/Canvas.as
@@ -110,7 +110,7 @@ package starling.display
         /** Resets the color to 'white' and alpha to '1'. */
         public function endFill():void
         {
-            if(_currentPath.length > 0) {
+            if(_currentPath && _currentPath.length > 0) {
                 const lastX:Number = _currentPath[_currentPath.length - 2];
                 const lastY:Number = _currentPath[_currentPath.length - 1];
 


### PR DESCRIPTION
Minot tweak needed for #1132.

It is possible for _currentPath to be null if only polygons have been drawn.

Code to reproduce the null exception:

```as3
var canvas:Canvas = new Canvas();
canvas.beginFill(0xff0000);
canvas.drawRectangle(0, 0, 150, 100);
canvas.endFill();
addChild(canvas);
```