### PR TITLE
Canvas: fix exception in lineTo() or curveTo() if _currentPath is null

### DIFF
--- a/starling/src/starling/display/Canvas.as
+++ b/starling/src/starling/display/Canvas.as
@@ -145,7 +145,13 @@ package starling.display
         public function lineTo(x:Number, y:Number):void
         {
             // TODO: This implementation too simple for strokes, only works for fills
-            if(_currentPath.length == 0)
+            if(_currentPath == null)
+            {
+                _currentPath = new Vector.<Number>();
+                _currentPath.push(0);
+                _currentPath.push(0);
+            }
+            else if(_currentPath.length == 0)
             {
                 _currentPath.push(0);
                 _currentPath.push(0);
@@ -164,7 +170,13 @@ package starling.display
          */
         public function curveTo(controlX:Number, controlY:Number, anchorX:Number, anchorY:Number):void
         {
-            if(_currentPath.length == 0)
+            if(_currentPath == null)
+            {
+                _currentPath = new Vector.<Number>();
+                _currentPath.push(0);
+                _currentPath.push(0);
+            }
+            else if(_currentPath.length == 0)
             {
                 _currentPath.push(0);
                 _currentPath.push(0);


### PR DESCRIPTION
Flash allows moveTo() to be omitted before calling lineTo() or curveTo(), and it will automatically insert moveTo(0, 0).

These methods already checked if _currentPath.length == 0 and added the automatic moveTo(0, 0), but _currentPath could also be null.

Code to reproduce:

```as3
var canvas:Canvas = new Canvas();
canvas.beginFill(0xff0000);
// should be able to omit canvas.moveTo(0, 0) here
canvas.lineTo(100, 50);
canvas.lineTo(50, 100);
canvas.endFill();
addChild(canvas);
```